### PR TITLE
build.sc: fix missing forkArgs in wrong place

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -142,6 +142,7 @@ object ventus extends CommonModule {
 
   // use scalatest as your test framework
   object tests extends Tests with TestModule.ScalaTest {
+    override def forkArgs = Seq("-Xmx32G", "-Xss192m")
     override def moduleDeps = super.moduleDeps ++ Seq(dependencies.`fpuv2`.build.fpuv2.test)
     override def ivyDeps = super.ivyDeps() ++ Agg(
       ivys.chiseltest,


### PR DESCRIPTION
关于jvm堆内存的配置-Xmx, see [this pr in xiangshan](https://github.com/OpenXiangShan/XiangShan/pull/842)