### PR TITLE
Add missing copyright and license

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
 // Import Mill dependencies
 import mill._
 import mill.scalalib._

--- a/common.sc
+++ b/common.sc
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
 import mill._
 import mill.scalalib._
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
 with import <nixpkgs> {
   config = {
     packageOverrides = pkgs: with pkgs; {

--- a/ventus/src/config/config.scala
+++ b/ventus/src/config/config.scala
@@ -1,13 +1,5 @@
-/*
- * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
- * Ventus is licensed under Mulan PSL v2.
- * You can use this software according to the terms and conditions of the Mulan PSL v2.
- * You may obtain a copy of Mulan PSL v2 at:
- *          http://license.coscl.org.cn/MulanPSL2
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
- * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
- * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
- * See the Mulan PSL v2 for more details. */
+// Copyright 2016-2019 SiFive, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 package config
 


### PR DESCRIPTION
Please notice, the build system codes that ventus copied from chipsalliance/playground never licensed under the mulan license and under the copyright of Jiuyang Liu <liu@jiuyang.me>.
This PR added the copyright back, in case of potential license abuse and propagation.

I also found it steals the copyright and license from https://github.com/chipsalliance/cde, please don't remove the copyright and license header.

And obviously the `ALU` was coming from the rocket-chip `ALU`. Please add the license back.