### PR TITLE
add exp unit for sfu

### DIFF
--- a/ventus/src/pipeline/EXPFP32.scala
+++ b/ventus/src/pipeline/EXPFP32.scala
@@ -230,7 +230,6 @@ class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
   class MULToADD extends Bundle {
     val c       = UInt(32.W)
     val index   = UInt(8.W)
-    val bypass  = Bool()
     val topCtrl = ctrlSignals.cloneType.asInstanceOf[T]
   }
   val mul   = Module(new MULFP32[MULToADD](new MULToADD))
@@ -243,7 +242,6 @@ class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
   mul.io.in.bits.rm           := io.in.bits.rm
   mul.io.in.bits.ctrl.c       := io.in.bits.c
   mul.io.in.bits.ctrl.index   := io.in.bits.index
-  mul.io.in.bits.ctrl.bypass  := false.B
   mul.io.in.bits.ctrl.topCtrl := io.in.bits.ctrl
   io.in.ready                 := mul.io.in.ready
 

--- a/ventus/src/pipeline/EXPFP32.scala
+++ b/ventus/src/pipeline/EXPFP32.scala
@@ -1,0 +1,534 @@
+package pipeline
+
+import chisel3._
+import chisel3.util._
+
+import fudian.{FCMA_ADD_s1, FCMA_ADD_s2, FMUL_s1, FMUL_s2, FMUL_s3, FMULToFADD, RawFloat}
+import fudian.utils.Multiplier
+
+object EXPFP32Parameters {
+  val LOG2E     = "h3FB8AA3B".U(32.W)
+  val C0        = "h3F800000".U(32.W)
+  val C1        = "h3F317218".U(32.W)
+  val C2        = "h3E75FDF0".U(32.W)
+  val MIN_INPUT = "hC2AE999A".U(32.W) // -87.3
+  val MAX_INPUT = "h42B16666".U(32.W) // +88.7
+  val ZERO      = 0.U(32.W)
+  val INF       = "h7F800000".U(32.W)
+  val NAN       = "h7FC00000".U(32.W)
+}
+
+object EXPFP32Utils {
+  implicit class DecoupledPipe[T <: Data](val decoupledBundle: DecoupledIO[T]) extends AnyVal {
+    def handshakePipeIf(en: Boolean): DecoupledIO[T] = {
+      if (en) {
+        val out = Wire(Decoupled(chiselTypeOf(decoupledBundle.bits)))
+        val rValid = RegInit(false.B)
+        val rBits  = Reg(chiselTypeOf(decoupledBundle.bits))
+
+        decoupledBundle.ready  := !rValid || out.ready
+        out.valid              := rValid
+        out.bits               := rBits
+
+        when(decoupledBundle.fire) {
+          rBits  := decoupledBundle.bits
+          rValid := true.B
+        } .elsewhen(out.fire) {
+          rValid := false.B
+        }
+
+        out
+      } else {
+        decoupledBundle
+      }
+    }
+  }
+}
+
+import EXPFP32Utils._
+
+// ======================================
+//   MULFP32
+//   输入： a, b, rm, ctrl
+//   输出： result, toAdd, ctrl
+// ======================================
+class MULFP32[T <: Bundle](ctrlSignals: T) extends Module {
+  val expWidth  = 8
+  val precision = 24
+
+  class InBundle extends Bundle {
+    val a    = UInt(32.W)
+    val b    = UInt(32.W)
+    val rm   = UInt(3.W)
+    val ctrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  class OutBundle extends Bundle {
+    val result = UInt(32.W)
+    val toAdd  = new FMULToFADD(expWidth, precision)
+    val ctrl   = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+
+  val mul   = Module(new Multiplier(precision + 1, pipeAt = Seq()))
+  val mulS1 = Module(new FMUL_s1(expWidth, precision))
+  val mulS2 = Module(new FMUL_s2(expWidth, precision))
+  val mulS3 = Module(new FMUL_s3(expWidth, precision))
+
+  mulS1.io.a  := io.in.bits.a
+  mulS1.io.b  := io.in.bits.b
+  mulS1.io.rm := io.in.bits.rm
+
+  val rawA = RawFloat.fromUInt(io.in.bits.a, expWidth, precision)
+  val rawB = RawFloat.fromUInt(io.in.bits.b, expWidth, precision)
+  mul.io.a := rawA.sig
+  mul.io.b := rawB.sig
+  mul.io.regEnables.foreach(_ := true.B)
+
+  val s1 = Wire(Decoupled(new Bundle {
+    val mulS1Out = mulS1.io.out.cloneType
+    val prod     = mul.io.result.cloneType
+    val ctrl     = ctrlSignals.cloneType.asInstanceOf[T]
+  }))
+  val s1Pipe = s1.handshakePipeIf(true)
+  s1.valid         := io.in.valid
+  s1.bits.mulS1Out := mulS1.io.out
+  s1.bits.prod     := mul.io.result
+  s1.bits.ctrl     := io.in.bits.ctrl
+  io.in.ready      := s1.ready
+
+  mulS2.io.in   := s1Pipe.bits.mulS1Out
+  mulS2.io.prod := s1Pipe.bits.prod
+
+  val s2 = Wire(Decoupled(new Bundle {
+    val mulS2Out = mulS2.io.out.cloneType
+    val ctrl     = ctrlSignals.cloneType.asInstanceOf[T]
+  }))
+  val s2Pipe = s2.handshakePipeIf(true)
+  s2.valid         := s1Pipe.valid
+  s2.bits.mulS2Out := mulS2.io.out
+  s2.bits.ctrl     := s1Pipe.bits.ctrl
+  s1Pipe.ready     := s2.ready
+
+  mulS3.io.in := s2Pipe.bits.mulS2Out
+
+  val s3     = Wire(Decoupled(new OutBundle))
+  val s3Pipe = s3.handshakePipeIf(true)
+  s3.valid          := s2Pipe.valid
+  s3.bits.result    := mulS3.io.result
+  s3.bits.toAdd     := mulS3.io.to_fadd
+  s3.bits.ctrl      := s2Pipe.bits.ctrl
+  s2Pipe.ready      := s3.ready
+
+  io.out <> s3Pipe
+}
+
+// ======================================
+//   CMAFP32 = A*B + C
+//   输入： a, b, c, rm, ctrl
+//   输出： result, ctrl
+// ======================================
+class CMAFP32[T <: Bundle](ctrlSignals: T) extends Module {
+  val expWidth  = 8
+  val precision = 24
+
+  class InBundle extends Bundle {
+    val a     = UInt(32.W)
+    val b     = UInt(32.W)
+    val c     = UInt(32.W)
+    val rm    = UInt(3.W)
+    val ctrl  = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  class OutBundle extends Bundle {
+    val result = UInt(32.W)
+    val ctrl   = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+
+  class MULToADD extends Bundle {
+    val c       = UInt(32.W)
+    val topCtrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  val mul   = Module(new MULFP32[MULToADD](new MULToADD))
+  val addS1 = Module(new FCMA_ADD_s1(expWidth, precision * 2, precision))
+  val addS2 = Module(new FCMA_ADD_s2(expWidth, precision * 2, precision))
+
+  mul.io.in.valid             := io.in.valid
+  mul.io.in.bits.a            := io.in.bits.a
+  mul.io.in.bits.b            := io.in.bits.b
+  mul.io.in.bits.rm           := io.in.bits.rm
+  mul.io.in.bits.ctrl.c       := io.in.bits.c
+  mul.io.in.bits.ctrl.topCtrl := io.in.bits.ctrl
+  io.in.ready                 := mul.io.in.ready
+
+  addS1.io.a             := Cat(mul.io.out.bits.ctrl.c, 0.U(precision.W))
+  addS1.io.b             := mul.io.out.bits.toAdd.fp_prod.asUInt
+  addS1.io.b_inter_valid := true.B
+  addS1.io.b_inter_flags := mul.io.out.bits.toAdd.inter_flags
+  addS1.io.rm            := mul.io.out.bits.toAdd.rm
+
+  val s4 = Wire(Decoupled(new Bundle {
+    val out  = addS1.io.out.cloneType
+    val ctrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }))
+  val s4Pipe = s4.handshakePipeIf(true)
+  s4.valid         := mul.io.out.valid
+  s4.bits.out      := addS1.io.out
+  s4.bits.ctrl     := mul.io.out.bits.ctrl.topCtrl
+  mul.io.out.ready := s4.ready
+
+  addS2.io.in := s4Pipe.bits.out
+
+  val s5     = Wire(Decoupled(new OutBundle))
+  val s5Pipe = s5.handshakePipeIf(true)
+  s5.valid       := s4Pipe.valid
+  s5.bits.result := addS2.io.result
+  s5.bits.ctrl   := s4Pipe.bits.ctrl
+  s4Pipe.ready   := s5.ready
+
+  io.out <> s5Pipe
+}
+
+// ======================================
+//   CMAFP32LUTParallel = A*B + C && lut(index)
+//   输入： a, b, c, rm, ctrl
+//   输出： result, ctrl
+// ======================================
+class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
+  val expWidth  = 8
+  val precision = 24
+
+  class InBundle extends Bundle {
+    val a     = UInt(32.W)
+    val b     = UInt(32.W)
+    val c     = UInt(32.W)
+    val index = UInt(8.W)
+    val rm    = UInt(3.W)
+    val ctrl  = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  class OutBundle extends Bundle {
+    val result = UInt(32.W)
+    val value  = UInt(32.W)
+    val ctrl   = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+
+  class MULToADD extends Bundle {
+    val c       = UInt(32.W)
+    val index   = UInt(8.W)
+    val topCtrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  val mul   = Module(new MULFP32[MULToADD](new MULToADD))
+  val addS1 = Module(new FCMA_ADD_s1(expWidth, precision * 2, precision))
+  val addS2 = Module(new FCMA_ADD_s2(expWidth, precision * 2, precision))
+
+  mul.io.in.valid             := io.in.valid
+  mul.io.in.bits.a            := io.in.bits.a
+  mul.io.in.bits.b            := io.in.bits.b
+  mul.io.in.bits.rm           := io.in.bits.rm
+  mul.io.in.bits.ctrl.c       := io.in.bits.c
+  mul.io.in.bits.ctrl.index   := io.in.bits.index
+  mul.io.in.bits.ctrl.topCtrl := io.in.bits.ctrl
+  io.in.ready                 := mul.io.in.ready
+
+  addS1.io.a             := Cat(mul.io.out.bits.ctrl.c, 0.U(precision.W))
+  addS1.io.b             := mul.io.out.bits.toAdd.fp_prod.asUInt
+  addS1.io.b_inter_valid := true.B
+  addS1.io.b_inter_flags := mul.io.out.bits.toAdd.inter_flags
+  addS1.io.rm            := mul.io.out.bits.toAdd.rm
+
+  val s4 = Wire(Decoupled(new Bundle {
+    val out   = addS1.io.out.cloneType
+    val index = UInt(8.W)
+    val ctrl  = ctrlSignals.cloneType.asInstanceOf[T]
+  }))
+  val s4Pipe = s4.handshakePipeIf(true)
+  s4.valid         := mul.io.out.valid
+  s4.bits.out      := addS1.io.out
+  s4.bits.index    := mul.io.out.bits.ctrl.index
+  s4.bits.ctrl     := mul.io.out.bits.ctrl.topCtrl
+  mul.io.out.ready := s4.ready
+
+  addS2.io.in := s4Pipe.bits.out
+
+  val s5     = Wire(Decoupled(new OutBundle))
+  val s5Pipe = s5.handshakePipeIf(true)
+  s5.valid       := s4Pipe.valid
+  s5.bits.result := addS2.io.result
+  s5.bits.ctrl   := s4Pipe.bits.ctrl
+  s4Pipe.ready   := s5.ready
+
+  val table = VecInit((0 until 256).map { i =>
+    val sign = (i >> 7) & 1
+    val mag  = i & 0x7f
+    val x = if (sign == 1) -(mag.toDouble / 128.0) else (mag.toDouble / 128.0)
+    val y = Math.pow(2.0, x)
+    val bits = java.lang.Float.floatToIntBits(y.toFloat)
+    bits.U(32.W)
+  })
+
+  s5.bits.value := table(s4Pipe.bits.index)
+
+  io.out <> s5Pipe
+}
+
+class DecomposeFP32[T <: Bundle](ctrlSignals: T) extends Module {
+  class InBundle extends Bundle {
+    val y    = UInt(32.W)
+    val ctrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  class OutBundle extends Bundle {
+    val yi   = UInt(9.W)   // 符号 + 整数部分（8位）
+    val yfi  = UInt(8.W)   // 符号 + 小数高7位
+    val yfj  = UInt(32.W)  // 小数低位转FP32
+    val ctrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+ 
+  val expWidth  = 8
+  val precision = 24
+  
+  val raw = RawFloat.fromUInt(io.in.bits.y, expWidth, precision)
+  val sign = raw.sign
+  val exp  = raw.exp
+  val sig  = raw.sig
+ 
+  val expSigned = (exp.zext - 127.S).asSInt
+
+  val section1 = expSigned <= -8.S
+ 
+  // ===========================
+  // Section 1: expSigned <= -8
+  // ===========================
+  val yiS1  = Cat(sign, 0.U(8.W))
+  val yfiS1 = Cat(sign, 0.U(7.W))
+  val yfjS1 = io.in.bits.y
+ 
+  // ===========================
+  // Section 2: expSigned ∈ [-7, 7]
+  // ===========================
+  val sigExtended = Cat(0.U(7.W), sig, 0.U(7.W))
+  val sigShifted = Mux(expSigned >= 0.S, sigExtended << expSigned.asUInt, sigExtended >> (-expSigned).asUInt)
+
+  val intPart       = sigShifted(37, 30)
+  val fracHigh      = sigShifted(29, 23)
+  val fracLow       = sigShifted(22, 0)
+  val fracLowIsZero = fracLow === 0.U
+  val lzdCount      = PriorityEncoder(Reverse(fracLow))
+  val expBiased     = Mux(fracLowIsZero, 0.U(8.W), (119.U(8.W) - lzdCount)(7, 0))
+  val mantissa      = Mux(fracLowIsZero, 0.U(23.W), ((fracLow << (lzdCount + 1.U))(22, 0)))
+  val yiS2          = Cat(sign, intPart)
+  val yfiS2         = Cat(sign, fracHigh)
+  val yfjS2         = Cat(sign, expBiased, mantissa)
+
+  val s1     = Wire(Decoupled(new OutBundle))
+  val s1Pipe = s1.handshakePipeIf(true)
+ 
+  s1.valid     := io.in.valid
+  s1.bits.yi   := Mux(section1, yiS1,  yiS2)
+  s1.bits.yfi  := Mux(section1, yfiS1, yfiS2)
+  s1.bits.yfj  := Mux(section1, yfjS1, yfjS2)
+  s1.bits.ctrl := io.in.bits.ctrl
+  io.in.ready  := s1.ready
+ 
+  io.out <> s1Pipe
+}
+
+class FilterFP32[T <: Bundle](ctrlSignals: Bundle) extends Module {
+  class InBundle extends Bundle {
+    val in = UInt(32.W)
+    val ctrl = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  class OutBundle extends Bundle {
+    val out       = UInt(32.W)
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+    val ctrl      = ctrlSignals.cloneType.asInstanceOf[T]
+  }
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+
+  val s = io.in.bits.in(31)
+  val e = io.in.bits.in(30, 23)
+  val f = io.in.bits.in(22, 0)
+
+  val isInfPos = (e === "hFF".U) && (f === 0.U) && (s === 0.U)
+  val isInfNeg = (e === "hFF".U) && (f === 0.U) && (s === 1.U)
+  val isNaN    = (e === "hFF".U) && (f =/= 0.U)
+
+  val tooBig = (!s) && (io.in.bits.in > EXPFP32Parameters.MAX_INPUT) // +88.7
+  val tooNeg = s && (io.in.bits.in > EXPFP32Parameters.MIN_INPUT)    // -87.3
+
+  val bypass = isNaN || isInfPos || isInfNeg || tooBig || tooNeg
+
+  val filteredVal = Wire(UInt(32.W))
+  val bypassVal   = Wire(UInt(32.W))
+
+  when (isNaN) {
+    filteredVal := EXPFP32Parameters.ZERO
+    bypassVal   := EXPFP32Parameters.NAN
+  }.elsewhen (isInfPos || tooBig) {
+    filteredVal := EXPFP32Parameters.ZERO
+    bypassVal   := EXPFP32Parameters.INF
+  }.elsewhen (isInfNeg || tooNeg) {
+    filteredVal := EXPFP32Parameters.ZERO
+    bypassVal   := EXPFP32Parameters.ZERO
+  }.otherwise {
+    filteredVal := io.in.bits.in
+    bypassVal   := EXPFP32Parameters.ZERO
+  }
+
+  val s1     = Wire(Decoupled(new OutBundle))
+  val s1Pipe = s1.handshakePipeIf(true)
+  s1.valid          := io.in.valid
+  s1.bits.out       := filteredVal
+  s1.bits.bypass    := bypass
+  s1.bits.bypassVal := bypassVal
+  s1.bits.ctrl      := io.in.bits.ctrl
+  io.in.ready       := s1.ready
+
+  io.out <> s1Pipe
+}
+
+class EXPFP32 extends Module {
+  class InBundle extends Bundle {
+    val in = UInt(32.W)
+    val rm = UInt(3.W)
+  }
+  class OutBundle extends Bundle {
+    val out = UInt(32.W)
+  }
+  val io = IO(new Bundle {
+    val in  = Flipped(Decoupled(new InBundle))
+    val out = Decoupled(new OutBundle)
+  })
+
+  class FilterToMul0 extends Bundle {
+    val rm = UInt(3.W)
+  }
+  val filter = Module(new FilterFP32[FilterToMul0](new FilterToMul0))
+  io.in.ready               := filter.io.in.ready
+  filter.io.in.valid        := io.in.valid
+  filter.io.in.bits.in      := io.in.bits.in
+  filter.io.in.bits.ctrl.rm := io.in.bits.rm
+
+  class Mul0ToDecompose extends Bundle {
+    val rm        = UInt(3.W)
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+  }
+  val mul0 = Module(new MULFP32[Mul0ToDecompose](new Mul0ToDecompose))
+  filter.io.out.ready            := mul0.io.in.ready
+  mul0.io.in.valid               := filter.io.out.valid
+  mul0.io.in.bits.a              := filter.io.out.bits.out
+  mul0.io.in.bits.b              := EXPFP32Parameters.LOG2E
+  mul0.io.in.bits.rm             := filter.io.out.bits.ctrl.rm
+  mul0.io.in.bits.ctrl.rm        := filter.io.out.bits.ctrl.rm
+  mul0.io.in.bits.ctrl.bypass    := filter.io.out.bits.bypass
+  mul0.io.in.bits.ctrl.bypassVal := filter.io.out.bits.bypassVal
+
+  class DecomposeToCMA0 extends Bundle {
+    val rm        = UInt(3.W)
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+  }
+  val decompose = Module(new DecomposeFP32[DecomposeToCMA0](new DecomposeToCMA0))
+  mul0.io.out.ready                      := decompose.io.in.ready
+  decompose.io.in.valid                  := mul0.io.out.valid
+  decompose.io.in.bits.y                 := mul0.io.out.bits.result
+  decompose.io.in.bits.ctrl.rm           := filter.io.out.bits.ctrl.rm
+  decompose.io.in.bits.ctrl.bypass       := mul0.io.out.bits.ctrl.bypass
+  decompose.io.in.bits.ctrl.bypassVal    := mul0.io.out.bits.ctrl.bypassVal
+
+  class CMA0ToCMA1 extends Bundle {
+    val rm        = UInt(3.W)
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+    val yi        = UInt(9.W)
+    val yfi       = UInt(8.W)
+    val yfj       = UInt(32.W)
+  }
+  val cma0   = Module(new CMAFP32[CMA0ToCMA1](new CMA0ToCMA1))
+  decompose.io.out.ready         := cma0.io.in.ready
+  cma0.io.in.valid               := decompose.io.out.valid
+  cma0.io.in.bits.a              := decompose.io.out.bits.yfj
+  cma0.io.in.bits.b              := EXPFP32Parameters.C2
+  cma0.io.in.bits.c              := EXPFP32Parameters.C1
+  cma0.io.in.bits.rm             := decompose.io.out.bits.ctrl.rm
+  cma0.io.in.bits.ctrl.rm        := filter.io.out.bits.ctrl.rm
+  cma0.io.in.bits.ctrl.bypass    := decompose.io.out.bits.ctrl.bypass
+  cma0.io.in.bits.ctrl.bypassVal := decompose.io.out.bits.ctrl.bypassVal
+  cma0.io.in.bits.ctrl.yi        := decompose.io.out.bits.yi
+  cma0.io.in.bits.ctrl.yfi       := decompose.io.out.bits.yfi
+  cma0.io.in.bits.ctrl.yfj       := decompose.io.out.bits.yfj
+
+  class CMA1ToMUL1 extends Bundle {
+    val rm        = UInt(3.W)
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+    val yi        = UInt(9.W)
+  }
+  val cma1 = Module(new CMAFP32LUTParallel[CMA1ToMUL1](new CMA1ToMUL1))
+  cma0.io.out.ready              := cma1.io.in.ready
+  cma1.io.in.valid               := cma0.io.out.valid
+  cma1.io.in.bits.a              := cma0.io.out.bits.ctrl.yfj
+  cma1.io.in.bits.b              := cma0.io.out.bits.result
+  cma1.io.in.bits.c              := EXPFP32Parameters.C0
+  cma1.io.in.bits.index          := cma0.io.out.bits.ctrl.yfi
+  cma1.io.in.bits.rm             := cma0.io.out.bits.ctrl.rm
+  cma1.io.in.bits.ctrl.rm        := filter.io.out.bits.ctrl.rm
+  cma1.io.in.bits.ctrl.bypass    := cma0.io.out.bits.ctrl.bypass
+  cma1.io.in.bits.ctrl.bypassVal := cma0.io.out.bits.ctrl.bypassVal
+  cma1.io.in.bits.ctrl.yi        := cma0.io.out.bits.ctrl.yi
+
+  class MUL1ToMux extends Bundle {
+    val bypass    = Bool()
+    val bypassVal = UInt(32.W)
+    val yi        = UInt(9.W)
+  }
+  val mul1 = Module(new MULFP32[MUL1ToMux](new MUL1ToMux))
+  cma1.io.out.ready              := mul1.io.in.ready
+  mul1.io.in.valid               := cma1.io.out.valid
+  mul1.io.in.bits.a              := cma1.io.out.bits.result
+  mul1.io.in.bits.b              := cma1.io.out.bits.value
+  mul1.io.in.bits.rm             := cma1.io.out.bits.ctrl.rm
+  mul1.io.in.bits.ctrl.bypass    := cma1.io.out.bits.ctrl.bypass
+  mul1.io.in.bits.ctrl.bypassVal := cma1.io.out.bits.ctrl.bypassVal
+  mul1.io.in.bits.ctrl.yi        := cma1.io.out.bits.ctrl.yi
+
+  val fResult   = mul1.io.out.bits.result
+  val yi        = mul1.io.out.bits.ctrl.yi
+  val bypass    = mul1.io.out.bits.ctrl.bypass
+  val bypassVal = mul1.io.out.bits.ctrl.bypassVal
+  val ef        = fResult(30,23)
+  val mant      = fResult(22,0)
+  val sign      = yi(8)
+  val ei        = yi(7,0)
+  val e         = (ef.zext.asSInt + Mux(sign === 1.U, -ei.zext.asSInt, ei.zext.asSInt))(7, 0)
+  val mainOut   = Cat(0.U(1.W), e(7, 0), mant)
+  val out       = Mux(bypass, bypassVal, mainOut)
+
+  val s18 = Wire(Decoupled(new OutBundle))
+  val s18Pipe = s18.handshakePipeIf(true)
+  s18.valid         := mul1.io.out.valid
+  s18.bits.out      := out
+  mul1.io.out.ready := s18.ready
+
+  io.out <> s18Pipe
+}

--- a/ventus/src/pipeline/EXPFP32.scala
+++ b/ventus/src/pipeline/EXPFP32.scala
@@ -1,4 +1,4 @@
-package pipeline
+package pipeline 
 
 import chisel3._
 import chisel3.util._
@@ -46,6 +46,9 @@ object EXPFP32Utils {
 }
 
 import EXPFP32Utils._
+
+// All module are not designed for resue
+// I have no choice how to pass ctrl signals and bypass signals
 
 // ======================================
 //   MULFP32
@@ -227,6 +230,7 @@ class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
   class MULToADD extends Bundle {
     val c       = UInt(32.W)
     val index   = UInt(8.W)
+    val bypass  = Bool()
     val topCtrl = ctrlSignals.cloneType.asInstanceOf[T]
   }
   val mul   = Module(new MULFP32[MULToADD](new MULToADD))
@@ -239,6 +243,7 @@ class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
   mul.io.in.bits.rm           := io.in.bits.rm
   mul.io.in.bits.ctrl.c       := io.in.bits.c
   mul.io.in.bits.ctrl.index   := io.in.bits.index
+  mul.io.in.bits.ctrl.bypass  := false.B
   mul.io.in.bits.ctrl.topCtrl := io.in.bits.ctrl
   io.in.ready                 := mul.io.in.ready
 
@@ -269,6 +274,7 @@ class CMAFP32LUTParallel[T <: Bundle](ctrlSignals: T) extends Module {
   s5.bits.ctrl   := s4Pipe.bits.ctrl
   s4Pipe.ready   := s5.ready
 
+  // LUT stores 2^(fractional_part) for exp(x) = 2^(x * log2(e))
   val table = VecInit((0 until 256).map { i =>
     val sign = (i >> 7) & 1
     val mag  = i & 0x7f
@@ -373,34 +379,29 @@ class FilterFP32[T <: Bundle](ctrlSignals: Bundle) extends Module {
   val isNaN    = (e === "hFF".U) && (f =/= 0.U)
 
   val tooBig = (!s) && (io.in.bits.in > EXPFP32Parameters.MAX_INPUT) // +88.7
-  val tooNeg = s && (io.in.bits.in > EXPFP32Parameters.MIN_INPUT)    // -87.3
+  val tooNeg =   s  && (io.in.bits.in > EXPFP32Parameters.MIN_INPUT) // -87.3
 
   val bypass = isNaN || isInfPos || isInfNeg || tooBig || tooNeg
 
-  val filteredVal = Wire(UInt(32.W))
   val bypassVal   = Wire(UInt(32.W))
 
   when (isNaN) {
-    filteredVal := EXPFP32Parameters.ZERO
     bypassVal   := EXPFP32Parameters.NAN
   }.elsewhen (isInfPos || tooBig) {
-    filteredVal := EXPFP32Parameters.ZERO
     bypassVal   := EXPFP32Parameters.INF
   }.elsewhen (isInfNeg || tooNeg) {
-    filteredVal := EXPFP32Parameters.ZERO
     bypassVal   := EXPFP32Parameters.ZERO
   }.otherwise {
-    filteredVal := io.in.bits.in
     bypassVal   := EXPFP32Parameters.ZERO
   }
 
   val s1     = Wire(Decoupled(new OutBundle))
   val s1Pipe = s1.handshakePipeIf(true)
   s1.valid          := io.in.valid
-  s1.bits.out       := filteredVal
+  s1.bits.out       := Mux(bypass, s1Pipe.bits.out, io.in.bits.in)
   s1.bits.bypass    := bypass
-  s1.bits.bypassVal := bypassVal
-  s1.bits.ctrl      := io.in.bits.ctrl
+  s1.bits.bypassVal := Mux(bypass, bypassVal, s1Pipe.bits.bypassVal)
+  s1.bits.ctrl      := Mux(bypass, s1Pipe.bits.ctrl, io.in.bits.ctrl)
   io.in.ready       := s1.ready
 
   io.out <> s1Pipe
@@ -449,12 +450,12 @@ class EXPFP32 extends Module {
     val bypassVal = UInt(32.W)
   }
   val decompose = Module(new DecomposeFP32[DecomposeToCMA0](new DecomposeToCMA0))
-  mul0.io.out.ready                      := decompose.io.in.ready
-  decompose.io.in.valid                  := mul0.io.out.valid
-  decompose.io.in.bits.y                 := mul0.io.out.bits.result
-  decompose.io.in.bits.ctrl.rm           := filter.io.out.bits.ctrl.rm
-  decompose.io.in.bits.ctrl.bypass       := mul0.io.out.bits.ctrl.bypass
-  decompose.io.in.bits.ctrl.bypassVal    := mul0.io.out.bits.ctrl.bypassVal
+  mul0.io.out.ready                   := decompose.io.in.ready
+  decompose.io.in.valid               := mul0.io.out.valid
+  decompose.io.in.bits.y              := mul0.io.out.bits.result
+  decompose.io.in.bits.ctrl.rm        := mul0.io.out.bits.ctrl.rm
+  decompose.io.in.bits.ctrl.bypass    := mul0.io.out.bits.ctrl.bypass
+  decompose.io.in.bits.ctrl.bypassVal := mul0.io.out.bits.ctrl.bypassVal
 
   class CMA0ToCMA1 extends Bundle {
     val rm        = UInt(3.W)
@@ -471,7 +472,7 @@ class EXPFP32 extends Module {
   cma0.io.in.bits.b              := EXPFP32Parameters.C2
   cma0.io.in.bits.c              := EXPFP32Parameters.C1
   cma0.io.in.bits.rm             := decompose.io.out.bits.ctrl.rm
-  cma0.io.in.bits.ctrl.rm        := filter.io.out.bits.ctrl.rm
+  cma0.io.in.bits.ctrl.rm        := decompose.io.out.bits.ctrl.rm
   cma0.io.in.bits.ctrl.bypass    := decompose.io.out.bits.ctrl.bypass
   cma0.io.in.bits.ctrl.bypassVal := decompose.io.out.bits.ctrl.bypassVal
   cma0.io.in.bits.ctrl.yi        := decompose.io.out.bits.yi
@@ -492,7 +493,7 @@ class EXPFP32 extends Module {
   cma1.io.in.bits.c              := EXPFP32Parameters.C0
   cma1.io.in.bits.index          := cma0.io.out.bits.ctrl.yfi
   cma1.io.in.bits.rm             := cma0.io.out.bits.ctrl.rm
-  cma1.io.in.bits.ctrl.rm        := filter.io.out.bits.ctrl.rm
+  cma1.io.in.bits.ctrl.rm        := cma0.io.out.bits.ctrl.rm
   cma1.io.in.bits.ctrl.bypass    := cma0.io.out.bits.ctrl.bypass
   cma1.io.in.bits.ctrl.bypassVal := cma0.io.out.bits.ctrl.bypassVal
   cma1.io.in.bits.ctrl.yi        := cma0.io.out.bits.ctrl.yi
@@ -521,7 +522,7 @@ class EXPFP32 extends Module {
   val sign      = yi(8)
   val ei        = yi(7,0)
   val e         = (ef.zext.asSInt + Mux(sign === 1.U, -ei.zext.asSInt, ei.zext.asSInt))(7, 0)
-  val mainOut   = Cat(0.U(1.W), e(7, 0), mant)
+  val mainOut   = Cat(0.U(1.W), e(7, 0), mant) // range cutting ensures no overflow and underflow in exponent
   val out       = Mux(bypass, bypassVal, mainOut)
 
   val s18 = Wire(Decoupled(new OutBundle))

--- a/ventus/src/pipeline/execution.scala
+++ b/ventus/src/pipeline/execution.scala
@@ -911,8 +911,8 @@ class SFUexe extends Module{
   }
 
   val i_ready = MuxCase(intDiv(0).in.ready, Seq(
-    (i_ctrl.fp) -> floatDiv(0).in.ready,
-    (isExp)     -> exp(0).in.ready
+    (isExp)     -> exp(0).in.ready,
+    (i_ctrl.fp) -> floatDiv(0).in.ready
   ))
 
   data_buffer.ready:=state===s_finish&o_ready

--- a/ventus/src/pipeline/execution.scala
+++ b/ventus/src/pipeline/execution.scala
@@ -829,6 +829,8 @@ class SFUexe extends Module{
   val next_i_cnt = PriorityEncoder((mask_grp.asUInt & ( ~(1.U(num_thread.W)<<i_cnt)).asUInt))
   val i_valid = RegInit(false.B) // a better valid should change for each fire.
   val i_ctrl = data_buffer.bits.ctrl
+  val isExp = (i_ctrl.alu_fn === FN_EXP)
+
   val i_data1 = WireInit(VecInit(Seq.fill(num_sfu)(0.U(xLen.W))))
   val i_data2 = WireInit(VecInit(Seq.fill(num_sfu)(0.U(xLen.W))))
   val i_data3 = WireInit(VecInit(Seq.fill(num_sfu)(0.U(xLen.W))))
@@ -845,7 +847,9 @@ class SFUexe extends Module{
 
   val intDiv=VecInit(Seq.fill(num_sfu)(Module(new IntDivMod(xLen)).io))
   val floatDiv=VecInit(Seq.fill(num_sfu)(Module(new FloatDivSqrt).io))
-  val alu_out_arbiter=VecInit(Seq.fill(num_sfu)(Module(new Arbiter(UInt(xLen.W),2)).io))
+  val exp = VecInit(Seq.fill(num_sfu)(Module(new EXPFP32).io))
+
+  val alu_out_arbiter=VecInit(Seq.fill(num_sfu)(Module(new Arbiter(UInt(xLen.W),3)).io))
   alu_out_arbiter.foreach(x=>x.out.ready:=alu_out_arbiter.map(x=>x.out.valid).reduce(_&_))// i_ctrl.wfd & result_v.io.enq.ready | i_ctrl.wxd & result_x.io.enq.ready | !(i_ctrl.wxd&i_ctrl.wfd)
   //result_x.io.enq.bits:=Cat(out_data(0),i_ctrl.wxd,i_ctrl.reg_idxw,i_ctrl.wid).asTypeOf(new WriteScalarCtrl)
   //result_v.io.enq.bits:=Cat(out_data.asUInt,data_buffer.bits.mask.asUInt,i_ctrl.wfd,i_ctrl.reg_idxw,i_ctrl.wid).asTypeOf(new WriteVecCtrl)
@@ -865,35 +869,52 @@ class SFUexe extends Module{
   result_x.io.enq.valid:=state===s_finish&i_ctrl.wxd
   result_v.io.enq.valid:=state===s_finish&i_ctrl.wvd
   val o_ready= i_ctrl.isvec&result_v.io.enq.ready | !i_ctrl.isvec & result_x.io.enq.ready
-  for(i <- 0 until num_sfu)
-  {
-    alu_out_arbiter(i).in(0).bits := Mux(i_ctrl.alu_fn(0), intDiv(i).out.bits.r, intDiv(i).out.bits.q)
-    alu_out_arbiter(i).in(1).bits := floatDiv(i).out.bits.result
+
+  for (i <- 0 until num_sfu) {
+    alu_out_arbiter(i).in(0).bits  := Mux(i_ctrl.alu_fn(0), intDiv(i).out.bits.r, intDiv(i).out.bits.q)
+    alu_out_arbiter(i).in(1).bits  := floatDiv(i).out.bits.result
     alu_out_arbiter(i).in(0).valid := intDiv(i).out.valid
     alu_out_arbiter(i).in(1).valid := floatDiv(i).out.valid
-    intDiv(i).out.ready := alu_out_arbiter(i).in(0).ready
-    floatDiv(i).out.ready := alu_out_arbiter(i).in(1).ready
+    alu_out_arbiter(i).in(2).bits  := exp(i).out.bits.out
+    alu_out_arbiter(i).in(2).valid := exp(i).out.valid
+    intDiv(i).out.ready            := alu_out_arbiter(i).in(0).ready
+    floatDiv(i).out.ready          := alu_out_arbiter(i).in(1).ready
+    exp(i).out.ready               := alu_out_arbiter(i).in(2).ready
 
-    intDiv(i).in.bits.a := 1.U
-    intDiv(i).in.bits.d := 1.U
-    floatDiv(i).in.bits.a :=(0x3f800000L).U(32.W)
-    floatDiv(i).in.bits.b :=(0x3f800000L).U(32.W)
-    floatDiv(i).in.bits.c :=(0x3f800000L).U(32.W)
-    for(j <- 0 until num_grp){
-      when(j.asUInt===i_cnt & i_mask(i)){
-    intDiv(i).in.bits.a := i_data1(i)
-    intDiv(i).in.bits.d := i_data2(i)
-    floatDiv(i).in.bits.a := i_data1(i)
-    floatDiv(i).in.bits.b := i_data2(i)
-    floatDiv(i).in.bits.c := i_data3(i)}}
+    intDiv(i).in.bits.a   := 1.U
+    intDiv(i).in.bits.d   := 1.U
+    floatDiv(i).in.bits.a := (0x3f800000L).U(32.W)
+    floatDiv(i).in.bits.b := (0x3f800000L).U(32.W)
+    floatDiv(i).in.bits.c := (0x3f800000L).U(32.W)
+    exp(i).in.bits.in     := (0x3f800000L).U(32.W)
+
+    for (j <- 0 until num_grp) {
+      when(j.asUInt === i_cnt & i_mask(i)) {
+        intDiv(i).in.bits.a   := i_data1(i)
+        intDiv(i).in.bits.d   := i_data2(i)
+        floatDiv(i).in.bits.a := i_data1(i)
+        floatDiv(i).in.bits.b := i_data2(i)
+        floatDiv(i).in.bits.c := i_data3(i)
+        exp(i).in.bits.in     := i_data2(i)
+      }
+    }
+
     intDiv(i).in.bits.signed := !i_ctrl.alu_fn(1)
-    floatDiv(i).in.bits.rm := io.rm
-    floatDiv(i).in.bits.op := i_ctrl.alu_fn(2, 0)
+    floatDiv(i).in.bits.rm   := io.rm
+    floatDiv(i).in.bits.op   := i_ctrl.alu_fn(2, 0)
+    exp(i).in.bits.rm        := io.rm
 
-    intDiv(i).in.valid := !i_ctrl.fp & i_valid
-    floatDiv(i).in.valid := i_ctrl.fp & i_valid
+    intDiv(i).in.valid   := i_valid && !i_ctrl.fp && !isExp
+    floatDiv(i).in.valid := i_valid &&  i_ctrl.fp  && !isExp
+    exp(i).in.valid      := i_valid &&  isExp
+
   }
-    val i_ready = Mux(i_ctrl.fp, floatDiv(0).in.ready, intDiv(0).in.ready)
+
+  val i_ready = MuxCase(intDiv(0).in.ready, Seq(
+    (i_ctrl.fp) -> floatDiv(0).in.ready,
+    (isExp)     -> exp(0).in.ready
+  ))
+
   data_buffer.ready:=state===s_finish&o_ready
 
   val alu_out_fire = alu_out_arbiter(0).out.fire


### PR DESCRIPTION
	new file:   ventus/src/pipeline/EXPFP32.scala
	modified:   ventus/src/pipeline/execution.scala

## 说明
1. 复用了香山的浮点单元[FMUL, FCMA, RawFloat]
2. 针对 FP32 可表示范围，将输入限制在 [-87.3, 88.7] 之间。对于区间左侧的值直接返回0， 对于区间右侧的值直接返回 +inf，特殊输入 [-inf +inf nan] 分别返回 [0 +inf nan]。  实际 exp 函数的有效输入范围略大于裁剪区间。
3. 最大相对误差和和平均相对误差均收敛在 $10^{-6}$ 级别，最大相对误差约 $1\times10^{-6}$，平均相对误差约 $4\times10^{-6}$。注意使用 C 语言的 <math.h> 的 expf() 函数作为 golden，本身可能有不合适之处。
## 问题
1. 暂时没有找到一种优雅的方式传递控制信号和旁路信号。
2. 没有设计 bypass 路径关闭主路径流水，功耗大（暂时没有找到合适的方式）。
## 测试
参考 @liuweibupt 的 Ventus-OpenCL-Testcase 仓库。

exp.kl
```
__kernel void exp_test(__global float *input, __global float *output)
{
    int tid = get_global_id(0);

    float value = input[tid];
    float result;

    __asm__ volatile (
        "vfexp %0, %1\n"
        : "=vr"(result)
        : "vr"(value)
    );

    output[tid] = result;
}
```

main.cc
```
#include <cstddef>
#define CL_TARGET_OPENCL_VERSION 120
#include <CL/cl.h>
#include <cmath>
#include <cstdio>
#include <cstdlib>
#include <random>
#include <vector>

#define CHECK(clcall)                                                          \
  if (clcall != CL_SUCCESS) {                                                  \
    fprintf(stderr, "OpenCL Error %d at line %d\n", clcall, __LINE__);         \
    exit(1);                                                                   \
  }

int main() {
  const int N = 10000;
  std::vector<float> x(N), y(N), ref(N);

  std::mt19937 rng(10086);
  std::uniform_real_distribution<float> dist(-87.3f, 88.7f);
  for (int i = 0; i < N; ++i)
    x[i] = dist(rng);

  // Load platform/device
  cl_platform_id platform;
  cl_device_id device;
  cl_context context;
  cl_command_queue queue;
  CHECK(clGetPlatformIDs(1, &platform, nullptr));
  CHECK(clGetDeviceIDs(platform, CL_DEVICE_TYPE_DEFAULT, 1, &device, nullptr));
  context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, nullptr);
  queue = clCreateCommandQueue(context, device, 0, nullptr);

  // Load kernel
  FILE *f = fopen("exp.cl", "rb");
  fseek(f, 0, SEEK_END);
  size_t size = ftell(f);
  rewind(f);
  std::vector<char> src(size + 1);
  fread(src.data(), 1, size, f);
  src[size] = 0;
  fclose(f);

  cl_int err;
  const char *srcptr = src.data();
  cl_program prog = clCreateProgramWithSource(context, 1, &srcptr, &size, &err);
  CHECK(clBuildProgram(prog, 1, &device, nullptr, nullptr, nullptr));

  cl_kernel kernel = clCreateKernel(prog, "exp_test", &err);
  CHECK(err);

  // Buffers
  cl_mem bufX = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
                               sizeof(float) * N, x.data(), nullptr);
  cl_mem bufY = clCreateBuffer(context, CL_MEM_WRITE_ONLY, sizeof(float) * N,
                               nullptr, nullptr);

  // Set args
  CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &bufX));
  CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &bufY));

  size_t global = N;
  CHECK(clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global, nullptr, 0,
                               nullptr, nullptr));
  CHECK(clFinish(queue));
  CHECK(clEnqueueReadBuffer(queue, bufY, CL_TRUE, 0, sizeof(float) * N,
                            y.data(), 0, nullptr, nullptr));

  // Compute reference & compare
  int pass = 0;
  float max_err = 0;
  float total_err = 0;
  for (int i = 0; i < N; ++i) {
    ref[i] = expf(x[i]);
    float err = fabsf((y[i] - ref[i]) / (ref[i] == 0.0f ? 1.0f : ref[i]));
    if (err < 1e-4f)
      pass++;
    if (err > max_err)
      max_err = err;
    total_err += err;
    printf("x=%+12.6e, y=%+12.6e, ref=%+12.6e, err=%+12.6e\n", x[i], y[i],
           ref[i], err);
  }

  printf("%d/%d PASS, max_err = %+12.6e, avg_err = %+12.6e\n", pass, N, max_err,
         total_err / N);

  clReleaseMemObject(bufX);
  clReleaseMemObject(bufY);
  clReleaseKernel(kernel);
  clReleaseProgram(prog);
  clReleaseCommandQueue(queue);
  clReleaseContext(context);
  return 0;
}
```

编译
```
clang++ -g -O2 -std=c++11 -I. main.cc -o exp.out -I/include -L/lib -lOpenCL -Wno-unused-result
```

运行
```
VENTUS_BACKEND=rtlsim ./exp.out
```