### PR TITLE
fix(amo_dec): register ventus amo decode lut

### DIFF
--- a/ventus/src/pipeline/DecodeUnit.scala
+++ b/ventus/src/pipeline/DecodeUnit.scala
@@ -555,11 +555,12 @@ class InstrDecodeV2 extends Module {
   }
 
   val ctrlSignals = (0 until num_fetch).map( i => {
-    val lut = Seq(IDecodeLUT_IMF.table, IDecodeLUT_V.table, IDecodeLUT_VL.table, IDecodeLUT_VC.table).map { t =>
+    val lut = Seq(IDecodeLUT_IMF.table, IDecodeLUT_V.table, IDecodeLUT_VL.table, IDecodeLUT_VC.table, IDecodeLUT_A.table).map { t =>
       ListLookup(io.inst(i), IDecode.default, t)
     }
     ListLookup(io.inst(i)(6, 0), lut(0),
       Array(
+        BitPat("b0101111") -> lut(4),
         BitPat("b1010111") -> lut(1),
         BitPat("b1111011") -> lut(2),
         BitPat("b0?00111") -> lut(2),


### PR DESCRIPTION
# Description

  This fixes the atomic instruction decoding.

 # Issue

  Ventus defines `IDecodeLUT_A` for `RV32A AMO` instructions, but the table was not included in the main decode LUT list. The AMO opcode `0101111` was also not mapped to `IDecodeLUT_A`.

  As a result, AMO instructions such as `amoor.w`, `amoswap.w`, and `amomaxu.w` fall back to `IDecode.default`, causing incorrect control signals for atomic  instructions.
