### PR TITLE
feat: add waveform window option

### DIFF
--- a/sim-verilator/README.md
+++ b/sim-verilator/README.md
@@ -112,6 +112,8 @@ Run with `--help` to view all options. Commonly used ones include:
   Loads command-line options from the specified file (equivalent to passing the file contents directly as arguments).
 * `--waveform`
   Enables waveform export. Generated FST files are placed in the `logs` directory and can be viewed with **gtkwave**.
+* `--waveform-window BEGIN END`
+  Enables waveform export only for the `[BEGIN, END)` simulation-time window. This is useful after an assertion identifies the failure cycle.
 * `--dump-mem 0x90001000,0x90001020`
   Dumps memory contents in the specified range (`0x90001000 ≤ addr ≤ 0x90001020`) after simulation. Data is printed in 4-byte lines to help verify correctness.
 

--- a/sim-verilator/cmdarg.cpp
+++ b/sim-verilator/cmdarg.cpp
@@ -101,6 +101,20 @@ int parse_arg(
             config->waveform.enable = true;
             config->waveform.time_begin = 0;
             config->waveform.time_end = -1;
+        } else if (args[argid] == "--waveform-window") {
+            if (argid + 2 >= args.size()) {
+                cmdarg_error(std::vector<std::string>(args.begin() + argid, args.end()));
+            } else {
+                uint64_t time_begin = std::stoull(args[++argid]);
+                uint64_t time_end = std::stoull(args[++argid]);
+                if (time_end <= time_begin) {
+                    std::cout << "Error: --waveform-window needs END > BEGIN\n";
+                    cmdarg_error(std::vector<std::string>(args.begin() + argid - 2, args.begin() + argid + 1));
+                }
+                config->waveform.enable = true;
+                config->waveform.time_begin = time_begin;
+                config->waveform.time_end = time_end;
+            }
         } else if (args[argid] == "--snapshot") {
             if (++argid >= args.size()) {
                 cmdarg_error(std::vector<std::string>(args.begin() + argid - 1, args.end()));
@@ -254,6 +268,7 @@ int cmdarg_help(int exit_id) {
         << "\n"
         << "--dump-mem BEGIN,END uint,uint   // 仿真结束后打印指定的内存地址范围[BEGIN,END]，4字节对齐\n"
         << "--waveform                       // 导出仿真波形fst文件，默认位置logs/\n"
+        << "--waveform-window BEGIN END      // 只导出[BEGIN,END)窗口内的fst波形\n"
         << "--sim-time-max NUM   uint        // number of simulation cycles\n"
         << "--snapshot INTERVAL  uint        // 每隔多少仿真时间生成一个快照，若为0则关闭快照功能\n"
         << std::endl;


### PR DESCRIPTION
Adds `--waveform-window BEGIN END` CLI option to limit FST waveform dumping to a specific simulation-time range.

This lets users choose a waveform window at runtime without rebuilding or changing compile-time configuration. It is useful for focused debug when the interesting cycle range is already known, while avoiding large full-run waveform files.

The new option is also documented in sim-verilator/README.md and --help.
 
