### PR TITLE
subcore: add SM partition baseline with shared memory fabric

### DIFF
--- a/ventus/src/L1Cache/DCache/CoreReqPipe.scala
+++ b/ventus/src/L1Cache/DCache/CoreReqPipe.scala
@@ -103,10 +103,10 @@ class CoreReqPipe(implicit p: Parameters) extends DCacheModule{
     // 让外部 in(1) 的 st0-hitRTAB 路径占掉最后一格 → 闭合 st1⇄RTAB 死锁环。
     val Req_st1_RTAB_reserve = Output(Bool())
     val CheckReq_WSHR       = Output(new WSHRreq)
-    // {S}MSHRmissReq.instrId width = max(WIdBits, log2Up(NMshrEntry)) to allow
-    // NMshrEntry > num_warp; see bugs/bfs4096-003/phase_4_report.md.
-    val Probe_SMSHR         = DecoupledIO(new SMSHRmissReq(bABits, tIBits, math.max(WIdBits, log2Up(NMshrEntry)), asidLen))//TODO add special MSHR
-    val MissReq_MSHR        = DecoupledIO(new MSHRmissReq(bABits, tIBits, math.max(WIdBits, log2Up(NMshrEntry)), asidLen))
+    // {S}MSHRmissReq.instrId carries the pipe-facing core instrId metadata.
+    // Keep it wide enough for subcore fabric ids while NMshrEntry remains local.
+    val Probe_SMSHR         = DecoupledIO(new SMSHRmissReq(bABits, tIBits, math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), asidLen))//TODO add special MSHR
+    val MissReq_MSHR        = DecoupledIO(new MSHRmissReq(bABits, tIBits, math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), asidLen))
     val MissCached_MSHR     = Output(Bool())
     val st1_valid           = Output(Bool())
     val st1_ready           = Output(Bool())

--- a/ventus/src/L1Cache/DCache/DCache.scala
+++ b/ventus/src/L1Cache/DCache/DCache.scala
@@ -16,12 +16,12 @@ import SRAMTemplate._
 import chisel3._
 import chisel3.util._
 import config.config.Parameters
-import top.parameters.{MMU_ENABLED, NUMBER_CU, dcache_BlockOffsetBits, dcache_BlockWords, dcache_MshrEntry, dcache_NSets, dcache_WordOffsetBits, num_block, num_thread}
+import top.parameters.{MMU_ENABLED, NUMBER_CU, dcache_BlockOffsetBits, dcache_BlockWords, dcache_MshrEntry, dcache_NSets, dcache_WordOffsetBits, lsu_mem_instr_id_bits, num_block, num_thread}
 import mmu.SV32.{asidLen, paLen, vaLen}
 //import pipeline.parameters._
 
 class VecMshrTargetInfo(implicit p: Parameters)extends DCacheBundle{
-  val instrId = UInt(WIdBits.W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   //val isWrite = Bool()
   val perLaneAddr = Vec(NLanes, new DCachePerLaneAddr)
 }
@@ -316,7 +316,7 @@ class DataCache(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) extends 
   // bugs/bfs4096-003/phase_4_report.md. V1 path is not elaborated, but the
   // named arg must match L1MSHR.scala's renamed parameter to keep the file
   // compilable.
-  val MshrAccess = Module(new MSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(WIdBits, log2Up(NMshrEntry)), NMshrEntry, NMshrSubEntry, asidLen))
+  val MshrAccess = Module(new MSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), NMshrEntry, NMshrSubEntry, asidLen))
   //val missRspFromMshr_st1 = Wire(Bool())
   val missRspTI_st1 = Wire(new VecMshrTargetInfo)
   val readmiss_st0_st1_match= Wire(Bool())

--- a/ventus/src/L1Cache/DCache/DCachev2.scala
+++ b/ventus/src/L1Cache/DCache/DCachev2.scala
@@ -17,7 +17,7 @@ import chisel3._
 import chisel3.util._
 import config.config.Parameters
 import firrtl.Utils._
-import top.parameters.{MMU_ENABLED, NUMBER_CU, dcache_BlockOffsetBits, dcache_BlockWords, dcache_MshrEntry, dcache_NSets, dcache_WordOffsetBits, num_block, num_thread}
+import top.parameters.{MMU_ENABLED, NUMBER_CU, dcache_BlockOffsetBits, dcache_BlockWords, dcache_MshrEntry, dcache_NSets, dcache_WordOffsetBits, lsu_mem_instr_id_bits, num_block, num_thread}
 import mmu.SV32.{asidLen, paLen, vaLen}
 import top.parameters.DCACHE_DEBUG
 import scala.tools.nsc.interpreter.Repl
@@ -72,9 +72,10 @@ class DataCachev2(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) extend
   // The MSHR class's `InstrIdBits` parameter (formerly `WIdBits` in V1 cache era) sets
   // the width of MSHRmissReq/RspOut.instrId. V2 carries an MSHR index in this field, not
   // a warp id; see L1MSHR.scala and bugs/bfs4096-003/phase_4_report.md. Pass
-  // max(WIdBits, log2Up(NMshrEntry)) so NMshrEntry can exceed num_warp.
-  val MshrAccess = Module(new MSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(WIdBits, log2Up(NMshrEntry)), NMshrEntry, NMshrSubEntry, asidLen))
-  val SMshrAccess = Module(new SpecialMSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(WIdBits, log2Up(NMshrEntry)), NMshrEntry, asidLen))
+  // max(pipe-facing instrId width, log2Up(NMshrEntry)) so subcore metadata
+  // remains intact while NMshrEntry remains local.
+  val MshrAccess = Module(new MSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), NMshrEntry, NMshrSubEntry, asidLen))
+  val SMshrAccess = Module(new SpecialMSHR(bABits = bABits, tIWidth = tIBits, InstrIdBits = math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), NMshrEntry, asidLen))
   val DataAccesses = Seq.tabulate(BlockWords) { i =>
     Module(new SRAMTemplate(
       gen=UInt(8.W),

--- a/ventus/src/L1Cache/DCache/MemRspPipe.scala
+++ b/ventus/src/L1Cache/DCache/MemRspPipe.scala
@@ -41,12 +41,12 @@ class MemRspPipe(implicit p: Parameters) extends DCacheModule{
 
          //st1
          val memRsp_coreRsp     = DecoupledIO(new CoreRspPipe_st2)
-         // MSHRmissRspOut.instrId width = max(WIdBits, log2Up(NMshrEntry)) to allow
-         // NMshrEntry > num_warp; see bugs/bfs4096-003/phase_4_report.md.
-         val MSHRMissRspOut     = Flipped(DecoupledIO(new MSHRmissRspOut(bABits, tIBits, math.max(WIdBits, log2Up(NMshrEntry)), asidLen)))
+         // MSHRmissRspOut.instrId carries the pipe-facing core instrId metadata.
+         // Keep it wide enough for subcore fabric ids while NMshrEntry remains local.
+         val MSHRMissRspOut     = Flipped(DecoupledIO(new MSHRmissRspOut(bABits, tIBits, math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), asidLen)))
          val MSHRMissRspOutAsid = if(MMU_ENABLED) Some(Input(UInt(asidLen.W))) else None
 
-         val SMSHRMissRspOut     = Flipped(DecoupledIO(new MSHRmissRspOut(bABits, tIBits, math.max(WIdBits, log2Up(NMshrEntry)), asidLen)))
+         val SMSHRMissRspOut     = Flipped(DecoupledIO(new MSHRmissRspOut(bABits, tIBits, math.max(lsu_mem_instr_id_bits, log2Up(NMshrEntry)), asidLen)))
          val SMSHRMissRspOutAsid = if(MMU_ENABLED) Some(Input(UInt(asidLen.W))) else None
 
          val dAmemRsp_wReq         = Output(Vec(BlockWords, new SRAMBundleAW(UInt(8.W), NSets * NWays, BytesOfWord)))

--- a/ventus/src/L1Cache/ICache/ICache.scala
+++ b/ventus/src/L1Cache/ICache/ICache.scala
@@ -22,9 +22,13 @@ import top.parameters._
 import top.cache_spike_info
 
 class ICachePipeReq(SV: mmu.SVParam)(implicit p: Parameters) extends ICacheBundle{
+  private val sourceWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
   val addr = UInt(WordLength.W)
   val mask = UInt(num_fetch.W)
   val warpid = UInt(WIdBits.W)
+  val source = UInt(sourceWidth.W)
+  val wf_tag = UInt(TAG_WIDTH.W)
+  val frontend_gen = UInt(frontend_gen_width.W)
   val asid = if(MMU_ENABLED) Some(UInt(asidLen.W)) else None
   val spike_info=if(SPIKE_OUTPUT) Some(new cache_spike_info(SV)) else None
 }
@@ -32,10 +36,14 @@ class ICachePipeFlush(implicit p: Parameters) extends ICacheBundle{
   val warpid = UInt(WIdBits.W)
 }
 class ICachePipeRsp(implicit p: Parameters) extends ICacheBundle{
+  private val sourceWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
   val addr = UInt(WordLength.W)
   val data = UInt((num_fetch*WordLength).W)
   val mask = UInt(num_fetch.W)
   val warpid = UInt(WIdBits.W)
+  val source = UInt(sourceWidth.W)
+  val wf_tag = UInt(TAG_WIDTH.W)
+  val frontend_gen = UInt(frontend_gen_width.W)
   val status = UInt(2.W)//目前只有LSB投入使用，1表示MISS，0表示HIT
 }
 /*
@@ -120,8 +128,14 @@ class InstructionCache(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) e
   val waymask_replace_st0 = tagAccess.io.waymaskReplacement
   val warpid_st1 = RegEnable(io.coreReq.bits.warpid, io.coreReq.ready)
   val mask_st1 = RegEnable(io.coreReq.bits.mask, io.coreReq.ready)
+  val source_st1 = RegEnable(io.coreReq.bits.source, io.coreReq.ready)
+  val wf_tag_st1 = RegEnable(io.coreReq.bits.wf_tag, io.coreReq.ready)
+  val frontend_gen_st1 = RegEnable(io.coreReq.bits.frontend_gen, io.coreReq.ready)
   val warpid_st2 = RegNext(warpid_st1)
   val mask_st2 = RegNext(mask_st1)
+  val source_st2 = RegNext(source_st1)
+  val wf_tag_st2 = RegNext(wf_tag_st1)
+  val frontend_gen_st2 = RegNext(frontend_gen_st1)
   val addr_st1 = RegEnable(io.coreReq.bits.addr, io.coreReq.ready)
   val addr_st2 = RegNext(addr_st1)
   if(MMU_ENABLED){
@@ -203,6 +217,9 @@ class InstructionCache(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) e
   io.coreRsp.bits.data := data_after_blockOffset_st2
   io.coreRsp.bits.warpid := warpid_st2
   io.coreRsp.bits.mask := mask_st2
+  io.coreRsp.bits.source := source_st2
+  io.coreRsp.bits.wf_tag := wf_tag_st2
+  io.coreRsp.bits.frontend_gen := frontend_gen_st2
   /*Mux(missRsp_from_mshr,
     //miss Rsp
     mshrAccess.io.missRspOut.bits.targetInfo>>(BlockOffsetBits+WordOffsetBits),
@@ -260,7 +277,9 @@ class InstructionCache(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) e
 
   // ******      core req ready
   //val coreRsp_QAlmstFull = coreRsp_Q.io.count === 2.U
-  io.coreReq.ready := true.B//!memRsp_Q.io.deq.valid && !mshrAccess.io.missRspOut.valid//mshrAccess.io.missReq.ready //&& !coreRsp_QAlmstFull
+  val sameBlockRefillConflict = io.coreReq.valid && memRsp_Q.io.deq.fire &&
+    get_blockAddr(io.coreReq.bits.addr) === mshrAccess.io.missRspOut.bits.blockAddr
+  io.coreReq.ready := !sameBlockRefillConflict
 
   // ******    self generate flushPipeline
   //保存两个周期的warp id，与当前输入id对比。

--- a/ventus/src/L1Cache/L1CacheParameters.scala
+++ b/ventus/src/L1Cache/L1CacheParameters.scala
@@ -48,7 +48,7 @@ trait HasL1CacheParameters extends HasRVGParameters{
   def NMshrEntry: Int = 4// replace
   def NMshrSubEntry: Int = 4// replace
   def bABits = TagBits+SetIdxBits
-  def tIBits = WIdBits+NLanes*(BlockOffsetBits+1+BytesOfWord)
+  def tIBits = lsu_mem_instr_id_bits+NLanes*(BlockOffsetBits+1+BytesOfWord)
 
   //for addr with full width or just block addr
   def get_tag(addr: UInt) = (addr >> (addr.getWidth-TagBits)).asUInt

--- a/ventus/src/L1Cache/L1Interfaces.scala
+++ b/ventus/src/L1Cache/L1Interfaces.scala
@@ -33,7 +33,7 @@ class DCachePerLaneAddr(implicit p: Parameters) extends DCacheBundle{
 }
 class DCacheCoreReq(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) extends DCacheBundle{
   //val ctrlAddr = new Bundle{
-  val instrId = UInt(WIdBits.W)//TODO length unsure
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val opcode = UInt(3.W)//0-read 1-write 3- flush/invalidate
   val param = UInt(4.W)
   val tag = UInt(TagBits.W)
@@ -45,13 +45,13 @@ class DCacheCoreReq(SV: Option[mmu.SVParam] = None)(implicit p: Parameters) exte
 }
 
 class DCacheCoreRsp(implicit p: Parameters) extends DCacheBundle{
-  val instrId = UInt(WIdBits.W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()
   val data = Vec(NLanes, UInt(WordLength.W))
   val activeMask = Vec(NLanes, Bool())//UInt(NLanes.W)
 }
 class DCacheCoreRsp_d(implicit p: Parameters) extends DCacheBundle{
-  val instrId = UInt(WIdBits.W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()
   val data = Vec(NLanesd, UInt(WordLength.W))
   val activeMask = Vec(NLanes, Bool())//UInt(NLanes.W)

--- a/ventus/src/L1Cache/ShareMem/ShareMem.scala
+++ b/ventus/src/L1Cache/ShareMem/ShareMem.scala
@@ -21,6 +21,7 @@ import top.parameters.sharedmem_depth
 import top.parameters.num_thread
 import top.parameters.BytesOfWord
 import top.parameters.num_lane
+import top.parameters.lsu_mem_instr_id_bits
 
 /*Version Note
 * DCacheCoreReq spec changed, shift some work to LSU
@@ -37,7 +38,7 @@ class ShareMemPerLaneAddr(implicit p: Parameters) extends ShareMemBundle{
 }
 class ShareMemCoreReq(implicit p: Parameters) extends ShareMemBundle{
   //val ctrlAddr = new Bundle{
-  val instrId = UInt(WIdBits.W)//TODO length unsure
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()//Vec(NLanes, Bool())
   //val tag = UInt(TagBits.W)
   val setIdx = UInt(SetIdxBits.W)
@@ -46,14 +47,14 @@ class ShareMemCoreReq(implicit p: Parameters) extends ShareMemBundle{
 }
 
 class ShareMemCoreRsp(implicit p: Parameters) extends ShareMemBundle{
-  val instrId = UInt(WIdBits.W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()
   val data = Vec(NLanes, UInt(WordLength.W))
   val activeMask = Vec(NLanes, Bool())//UInt(NLanes.W)
 }
 
 class ShareMemGrantMeta(implicit p: Parameters) extends ShareMemBundle{
-  val instrId = UInt(WIdBits.W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()
   val setIdx = UInt(SetIdxBits.W)
   val activeMask = Vec(NLanes, Bool())

--- a/ventus/src/pipeline/CSR.scala
+++ b/ventus/src/pipeline/CSR.scala
@@ -11,6 +11,7 @@
 package pipeline
 //source from https://github.com/lingscale/cc01/blob/master/src/main/scala/core/CSR.scala
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
 
@@ -362,16 +363,22 @@ class CSRFile extends Module {
   io.lsu_numt := wf_size_dispatch
 }
 
-class CSRexe extends Module {
-  val io = IO(new Bundle {
+@instantiable
+class CSRexe(val nWarps: Int = num_warp) extends Module {
+  private val localWarpIdxWidth = if (nWarps == 1) 1 else log2Ceil(nWarps)
+  private def localWarpIdx(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W) else wid(localWarpIdxWidth - 1, 0)
+  }
+
+  @public val io = IO(new Bundle {
     val in = Flipped(Decoupled(new csrExeData))
     val out = Decoupled(new WriteScalarCtrl())
     val out_v =Decoupled(new WriteVecCtrl())
     val rm_wid = Input(Vec(3,UInt(depth_warp.W)))
     val rm = Output(Vec(3,UInt(3.W)))
     val CTA2csr = Flipped(ValidIO(new warpReqData))
-    val sgpr_base = Output(Vec(num_warp,UInt((SGPR_ID_WIDTH+1).W)))
-    val vgpr_base = Output(Vec(num_warp,UInt((VGPR_ID_WIDTH+1).W)))
+    val sgpr_base = Output(Vec(nWarps,UInt((SGPR_ID_WIDTH+1).W)))
+    val vgpr_base = Output(Vec(nWarps,UInt((VGPR_ID_WIDTH+1).W)))
     //val warpsetting = Input()
     val lsu_wid = Input(UInt(depth_warp.W))
     val simt_wid = Input(UInt(depth_warp.W))
@@ -381,7 +388,7 @@ class CSRexe extends Module {
     val lsu_numt= Output(UInt(xLen.W))
     val simt_rpc = Output(UInt(xLen.W))
   })
-  val vCSR=VecInit(Seq.fill(num_warp)(Module(new CSRFile).io))
+  val vCSR=VecInit(Seq.fill(nWarps)(Module(new CSRFile).io))
   vCSR.foreach(x=>{
     x.ctrl:=io.in.bits.ctrl
     x.write:=false.B
@@ -389,45 +396,45 @@ class CSRexe extends Module {
     x.CTA2csr.valid:=false.B
     x.CTA2csr.bits:=io.CTA2csr.bits
   })
-  for(i<-0 until num_warp){
+  for(i<-0 until nWarps){
     io.sgpr_base(i):=vCSR(i).sgpr_base
     io.vgpr_base(i):=vCSR(i).vgpr_base
   }
-  io.lsu_tid:=vCSR(io.lsu_wid).lsu_tid
-  io.lsu_pds:=vCSR(io.lsu_wid).lsu_pds
-  io.lsu_numw:=vCSR(io.lsu_wid).lsu_numw
-  io.lsu_numt:=vCSR(io.lsu_wid).lsu_numt
-  io.simt_rpc:=vCSR(io.simt_wid).simt_rpc
+  io.lsu_tid:=vCSR(localWarpIdx(io.lsu_wid)).lsu_tid
+  io.lsu_pds:=vCSR(localWarpIdx(io.lsu_wid)).lsu_pds
+  io.lsu_numw:=vCSR(localWarpIdx(io.lsu_wid)).lsu_numw
+  io.lsu_numt:=vCSR(localWarpIdx(io.lsu_wid)).lsu_numt
+  io.simt_rpc:=vCSR(localWarpIdx(io.simt_wid)).simt_rpc
 
-  vCSR(io.in.bits.ctrl.wid).write:=io.in.fire
-  vCSR(io.CTA2csr.bits.wid).CTA2csr.valid:=io.CTA2csr.valid
+  vCSR(localWarpIdx(io.in.bits.ctrl.wid)).write:=io.in.fire
+  vCSR(localWarpIdx(io.CTA2csr.bits.wid)).CTA2csr.valid:=io.CTA2csr.valid
   val result=Module(new Queue(new WriteScalarCtrl,1,pipe=true))
   val result_v=Module(new Queue(new WriteVecCtrl,1,pipe=true))
   result.io.deq<>io.out
 
   io.in.ready:=result.io.enq.ready & !io.CTA2csr.valid & result_v.io.enq.ready
 
-  result.io.enq.valid:=io.in.fire & !vCSR(io.in.bits.ctrl.wid).wb_isvec
+  result.io.enq.valid:=io.in.fire & !vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_isvec
   result.io.enq.bits:=0.U.asTypeOf(new WriteScalarCtrl)
   result.io.enq.bits.reg_idxw:=io.in.bits.ctrl.reg_idxw
-  result.io.enq.bits.wxd:= !vCSR(io.in.bits.ctrl.wid).wb_isvec
-  result.io.enq.bits.wb_wxd_rd:=vCSR(io.in.bits.ctrl.wid).wb_wxd_rd
+  result.io.enq.bits.wxd:= !vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_isvec
+  result.io.enq.bits.wb_wxd_rd:=vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_wxd_rd
   result.io.enq.bits.warp_id:=io.in.bits.ctrl.wid
 
   result_v.io.deq <> io.out_v
 
-  result_v.io.enq.valid := io.in.fire & vCSR(io.in.bits.ctrl.wid).wb_isvec
+  result_v.io.enq.valid := io.in.fire & vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_isvec
   result_v.io.enq.bits := 0.U.asTypeOf(new WriteVecCtrl)
   result_v.io.enq.bits.reg_idxw := io.in.bits.ctrl.reg_idxw
-  result_v.io.enq.bits.wvd := vCSR(io.in.bits.ctrl.wid).wb_isvec
-  result_v.io.enq.bits.wb_wvd_rd := vCSR(io.in.bits.ctrl.wid).wb_wvd_rd
+  result_v.io.enq.bits.wvd := vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_isvec
+  result_v.io.enq.bits.wb_wvd_rd := vCSR(localWarpIdx(io.in.bits.ctrl.wid)).wb_wvd_rd
   result_v.io.enq.bits.warp_id := io.in.bits.ctrl.wid
   result_v.io.enq.bits.wvd_mask:= VecInit.fill(num_thread)(true.B)
 
   if(SPIKE_OUTPUT) result.io.enq.bits.spike_info.get:=io.in.bits.ctrl.spike_info.get
   if(SPIKE_OUTPUT) result_v.io.enq.bits.spike_info.get:=io.in.bits.ctrl.spike_info.get
   (0 until 3).foreach(x=>{
-    io.rm(x):=vCSR(io.rm_wid(x)).frm
+    io.rm(x):=vCSR(localWarpIdx(io.rm_wid(x))).frm
   })
 
 }

--- a/ventus/src/pipeline/CTA2warp.scala
+++ b/ventus/src/pipeline/CTA2warp.scala
@@ -60,27 +60,34 @@ class CTA2warp extends Module{
   })
   val idx_using = RegInit(0.U(num_warp.W))  // current active warps in sm
 
-  io.CTAreq.ready:=(~idx_using.andR)
   val data = RegInit(VecInit(Seq.fill(num_warp)(0.U(TAG_WIDTH.W)))) // every hw_warp record its wg&wf id
   io.wg_id_tag:=data(io.wg_id_lookup)
+  val has_free_slot = !idx_using.andR
   val idx_next_allocate = PriorityEncoder(~idx_using)
-  //idx_using:=Mux(io.warpRsp.fire&io.CTAreq.fire,idx_using&(~(1.U<<io.warpRsp.bits.wid)).asUInt&(1.U<<idx_next_allocate).asUInt,
-  //  Mux(io.warpRsp.fire,idx_using&(~(1.U<<io.warpRsp.bits.wid)).asUInt,
-  //  Mux(io.CTAreq.fire,idx_using&(1.U<<idx_next_allocate).asUInt,idx_using)))
-  idx_using:=(idx_using | ((1.U<<idx_next_allocate).asUInt & Fill(num_warp,io.CTAreq.fire))) & (~((Fill(num_warp,io.warpRsp.fire)).asUInt & ((1.U<<io.warpRsp.bits.wid)).asUInt)).asUInt
-  when(io.CTAreq.fire) {
+
+  io.warpReq.valid := io.CTAreq.valid && has_free_slot
+  io.warpReq.bits.CTAdata := io.CTAreq.bits
+  io.warpReq.bits.wid := idx_next_allocate
+  io.CTAreq.ready := has_free_slot && io.warpReq.ready
+
+  val launch_fire = io.warpReq.fire
+  val alloc_mask = (1.U << idx_next_allocate).asUInt & Fill(num_warp, launch_fire)
+  val free_mask = (1.U << io.warpRsp.bits.wid).asUInt & Fill(num_warp, io.warpRsp.fire)
+  idx_using := (idx_using | alloc_mask) & (~free_mask).asUInt
+  when(launch_fire) {
     data(idx_next_allocate):=io.CTAreq.bits.dispatch2cu_wf_tag_dispatch
   }
-  io.warpReq.valid:=io.CTAreq.fire
-  io.warpReq.bits.CTAdata:=io.CTAreq.bits
-  io.warpReq.bits.wid:=idx_next_allocate
 
   // TODO: Fix warp_scheduler warpRsp IO logic, which always requires ready=1
   // WorkAround: warp_scheduler requires io.wrapRsp.ready=1, use a large enough FIFO to satisfy it temporarily
-  val CTArsp_fifo = Queue(io.warpRsp, 16)
+  val CTArsp_fifo_enq = Wire(Decoupled(new CTArspData))
+  CTArsp_fifo_enq.valid := io.warpRsp.valid
+  CTArsp_fifo_enq.bits.cu2dispatch_wf_tag_done := data(io.warpRsp.bits.wid)
+  io.warpRsp.ready := CTArsp_fifo_enq.ready
+  val CTArsp_fifo = Queue(CTArsp_fifo_enq, 16)
   assert(io.warpRsp.ready, "warpRsp port requires ready=1, this FIFO is used to satisfy it, but not enough")
 
   CTArsp_fifo.ready := io.CTArsp.ready
-  io.CTArsp.bits.cu2dispatch_wf_tag_done := data(CTArsp_fifo.bits.wid)
+  io.CTArsp.bits := CTArsp_fifo.bits
   io.CTArsp.valid := CTArsp_fifo.valid
 }

--- a/ventus/src/pipeline/DecodeUnit.scala
+++ b/ventus/src/pipeline/DecodeUnit.scala
@@ -186,7 +186,7 @@ object IDecodeLUT_IMF{
     CSRRWI-> List(N,N,N,B_N,N,N,CSR.W,N,A3_X,A2_X,A1_IMM,IMM_Z,MEM_X,FN_ADD,N,M_X,N,N,N,N,N,N,Y,N,N,N,N),
     CSRRSI-> List(N,N,N,B_N,N,N,CSR.S,N,A3_X,A2_X,A1_IMM,IMM_Z,MEM_X,FN_ADD,N,M_X,N,N,N,N,N,N,Y,N,N,N,N),
     CSRRCI-> List(N,N,N,B_N,N,N,CSR.C,N,A3_X,A2_X,A1_IMM,IMM_Z,MEM_X,FN_ADD,N,M_X,N,N,N,N,N,N,Y,N,N,N,N),
-    CSRRSV-> List(N,N,N,B_N,N,N,CSR.S,N,A3_X,A2_X,A1_RS1,IMM_X,MEM_X,FN_ADD,N,M_X,N,N,N,N,N,N,Y,N,N,N,N),
+    CSRRSV-> List(N,N,N,B_N,N,N,CSR.S,N,A3_X,A2_X,A1_RS1,IMM_X,MEM_X,FN_ADD,N,M_X,N,N,N,Y,N,N,N,N,N,N,N),
 
     FENCE->  List(N,N,N,B_N,N,N,CSR.N,N,A3_X,A2_X,A1_X,IMM_I,MEM_X,FN_ADD,N,M_X,N,Y,N,N,N,N,Y,N,N,N,N),
     LW->     List(N,N,N,B_N,N,N,CSR.N,N,A3_X,A2_IMM,A1_RS1,IMM_I,MEM_W,FN_ADD,N,M_XRD,N,N,N,N,N,N,Y,N,N,N,N),
@@ -503,7 +503,7 @@ class InstrDecodeV2 extends Module {
     val pc = Input(UInt(addrLen.W))
     val wid = Input(UInt(depth_warp.W))
     val sm_id = Input(UInt(8.W))
-    val flush_wid = Flipped(ValidIO(UInt(depth_warp.W)))
+    val flush_wid = Input(UInt(num_warp.W))
     val control = Output(Vec(num_fetch, new CtrlSigs))
     val control_mask = Output(Vec(num_fetch, Bool()))
     val ibuffer_ready = Input(Vec(num_warp, Bool()))
@@ -539,9 +539,14 @@ class InstrDecodeV2 extends Module {
   // maskAfterExt       0    0    1    1                    |    1    0    1    0                       |   0    1    1    0
   // result             0    0   EA    B                    |   EA    0   EB    0                       |   0    A    B    0
   val scratchPads = RegInit(VecInit(Seq.fill(num_warp)(0.U.asTypeOf(new regext))))
-  when(io.flush_wid.valid){
-    scratchPads(io.flush_wid.bits) := 0.U.asTypeOf(new regext)
-    when(io.flush_wid.bits =/= io.wid && io.inst_mask.last && io.ibuffer_ready(io.wid)){
+  val currentFlushHit = io.flush_wid(io.wid)
+  when(io.flush_wid.orR){
+    (0 until num_warp).foreach { i =>
+      when(io.flush_wid(i)) {
+        scratchPads(i) := 0.U.asTypeOf(new regext)
+      }
+    }
+    when(!currentFlushHit && io.inst_mask.last && io.ibuffer_ready(io.wid)){
       scratchPads(io.wid) := regextInfo_pre.last
     }
   }.otherwise{

--- a/ventus/src/pipeline/FrontendCtrl.scala
+++ b/ventus/src/pipeline/FrontendCtrl.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
+import chisel3.util._
+import top.parameters._
+
+class FrontendCtrlIO extends Bundle {
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+
+  val pc_req = Vec(num_subcore, Flipped(DecoupledIO(new ICachePipeReq_np)))
+  val pc_rsp = Vec(num_subcore, ValidIO(new ICachePipeRsp_np))
+
+  val icache_req = DecoupledIO(new ICachePipeReq_np)
+  val icache_rsp = Flipped(DecoupledIO(new ICachePipeRsp_np))
+
+  val flush = Vec(num_subcore, Input(Valid(UInt(localDepthWarp.W))))
+  val flush_cache = Vec(num_subcore, Input(Valid(UInt(localDepthWarp.W))))
+  val launch_flush = Input(Valid(UInt(depth_warp.W)))
+  val rsp_kill = Input(Valid(UInt(depth_warp.W)))
+  val wg_tag_lookup = Input(Vec(num_warp, UInt(TAG_WIDTH.W)))
+  val frontend_gen_lookup = Input(Vec(num_warp, UInt(frontend_gen_width.W)))
+  val recently_freed = Input(UInt(num_warp.W))
+
+  val frontend_flush_mask = Output(UInt(num_warp.W))
+  val external_flush_pipe = ValidIO(UInt(depth_warp.W))
+
+  val accept_icache_rsp = Output(Bool())
+  val ibuffer_ready_for_rsp = Input(Bool())
+}
+
+@instantiable
+class FrontendCtrl extends Module {
+  @public val io = IO(new FrontendCtrlIO)
+
+  private def internalWid(sc: Int, localWid: UInt): UInt =
+    PipeSubcoreHelpers.internalWid(sc, localWid)
+
+  val sourceWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
+  val frontendOutstanding = RegInit(VecInit(Seq.fill(num_warp)(false.B)))
+  val frontendOutstandingAddr = RegInit(VecInit(Seq.fill(num_warp)(0.U(32.W))))
+  val frontendOutstandingSource = RegInit(VecInit(Seq.fill(num_warp)(0.U(sourceWidth.W))))
+  val frontendOutstandingWfTag = RegInit(VecInit(Seq.fill(num_warp)(0.U(TAG_WIDTH.W))))
+  val frontendOutstandingGen = RegInit(VecInit(Seq.fill(num_warp)(0.U(frontend_gen_width.W))))
+  val acceptIcacheRsp = Wire(Bool())
+  val pcReqArb = Module(new RRArbiter(new ICachePipeReq_np, num_subcore))
+
+  val flushMasks = (0 until num_subcore).map { sc =>
+    val flushWid = internalWid(sc, io.flush(sc).bits)
+    Mux(io.flush(sc).valid, UIntToOH(flushWid, num_warp), 0.U(num_warp.W))
+  }
+  val launchFlushMask =
+    Mux(io.launch_flush.valid, UIntToOH(io.launch_flush.bits, num_warp), 0.U(num_warp.W))
+  val frontendFlushMask = flushMasks.reduce(_ | _) | launchFlushMask
+  val frontendFlushMaskForReqBlock = RegNext(frontendFlushMask, 0.U(num_warp.W))
+  val frontendFlushMaskForRspDrop = RegNext(frontendFlushMask, 0.U(num_warp.W))
+  io.frontend_flush_mask := frontendFlushMask
+
+  val externalFlushMasks = (0 until num_subcore).map { sc =>
+    val flushWid = internalWid(sc, io.flush(sc).bits)
+    val flushCacheWid = internalWid(sc, io.flush_cache(sc).bits)
+    Seq(io.flush(sc).valid -> flushWid, io.flush_cache(sc).valid -> flushCacheWid)
+  }.reduce(_ ++ _)
+  io.external_flush_pipe.valid := externalFlushMasks.map(_._1).reduce(_ || _)
+  io.external_flush_pipe.bits := PriorityMux(externalFlushMasks)
+
+  val rspKillMask = Mux(io.rsp_kill.valid, UIntToOH(io.rsp_kill.bits, num_warp), 0.U(num_warp.W))
+  val frontendOutstandingClearMask = frontendFlushMask | rspKillMask
+
+  when(frontendOutstandingClearMask.orR) {
+    for (wid <- 0 until num_warp) {
+      when(frontendOutstandingClearMask(wid)) {
+        frontendOutstanding(wid) := false.B
+        frontendOutstandingAddr(wid) := 0.U
+        frontendOutstandingSource(wid) := 0.U
+        frontendOutstandingWfTag(wid) := 0.U
+        frontendOutstandingGen(wid) := 0.U
+      }
+    }
+  }
+
+  for (sc <- 0 until num_subcore) {
+    val reqWid = io.pc_req(sc).bits.warpid
+    val reqBlocked = frontendOutstanding(reqWid) ||
+      frontendFlushMask(reqWid) || frontendFlushMaskForReqBlock(reqWid)
+    pcReqArb.io.in(sc).valid := io.pc_req(sc).valid && !reqBlocked
+    pcReqArb.io.in(sc).bits := io.pc_req(sc).bits
+    pcReqArb.io.in(sc).bits.source := sc.U
+    pcReqArb.io.in(sc).bits.wf_tag := io.wg_tag_lookup(reqWid)
+    pcReqArb.io.in(sc).bits.frontend_gen := io.frontend_gen_lookup(reqWid)
+    io.pc_req(sc).ready := pcReqArb.io.in(sc).ready && !reqBlocked
+  }
+
+  io.icache_req.valid := pcReqArb.io.out.valid
+  io.icache_req.bits := pcReqArb.io.out.bits
+  pcReqArb.io.out.ready := io.icache_req.ready
+
+  when(io.icache_req.fire) {
+    frontendOutstanding(io.icache_req.bits.warpid) := true.B
+    frontendOutstandingAddr(io.icache_req.bits.warpid) := io.icache_req.bits.addr
+    frontendOutstandingSource(io.icache_req.bits.warpid) := io.icache_req.bits.source
+    frontendOutstandingWfTag(io.icache_req.bits.warpid) := io.icache_req.bits.wf_tag
+    frontendOutstandingGen(io.icache_req.bits.warpid) := io.icache_req.bits.frontend_gen
+  }
+
+  val rspWid = io.icache_rsp.bits.warpid
+  val rspOwner = PipeSubcoreHelpers.subcoreValue(rspWid)
+  val rspOutstandingMatch = frontendOutstanding(rspWid)
+  val rspAddrMatch = frontendOutstandingAddr(rspWid) === io.icache_rsp.bits.addr
+  val rspSourceMatch = frontendOutstandingSource(rspWid) === io.icache_rsp.bits.source
+  val rspWfTagMatch = io.icache_rsp.bits.wf_tag === frontendOutstandingWfTag(rspWid)
+  val rspFrontendGenMatch = io.icache_rsp.bits.frontend_gen === frontendOutstandingGen(rspWid)
+  val rspFlushHit = frontendFlushMaskForRspDrop(rspWid)
+  val rspKillHit = io.rsp_kill.valid && io.rsp_kill.bits === rspWid
+  acceptIcacheRsp := io.icache_rsp.valid &&
+    rspOutstandingMatch &&
+    rspAddrMatch &&
+    rspSourceMatch &&
+    rspWfTagMatch &&
+    rspFrontendGenMatch &&
+    !rspFlushHit &&
+    !rspKillHit
+
+  io.accept_icache_rsp := acceptIcacheRsp
+  io.icache_rsp.ready := Mux(acceptIcacheRsp, io.ibuffer_ready_for_rsp, true.B)
+
+  when(io.icache_rsp.fire && acceptIcacheRsp) {
+    frontendOutstanding(rspWid) := false.B
+  }
+
+  for (sc <- 0 until num_subcore) {
+    val rspHitsOwner = rspOwner === sc.U
+    io.pc_rsp(sc).valid := acceptIcacheRsp && rspHitsOwner
+    io.pc_rsp(sc).bits := io.icache_rsp.bits
+    io.pc_rsp(sc).bits.status := Mux(io.ibuffer_ready_for_rsp, io.icache_rsp.bits.status, 1.U(2.W))
+  }
+
+}

--- a/ventus/src/pipeline/LSU.scala
+++ b/ventus/src/pipeline/LSU.scala
@@ -12,6 +12,7 @@ package pipeline
 
 import top.parameters._
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import IDecode._
 import mmu.SV32.asidLen
@@ -35,7 +36,7 @@ class DCachePerLaneAddr extends Bundle{
 }
 
 class DCacheCoreReq_np extends Bundle{
-  val instrId = UInt(log2Up(lsu_nMshrEntry).W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
 //  val isWrite = Bool()
   val tag = UInt(dcache_TagBits.W)
   val setIdx = UInt(dcache_SetIdxBits.W)
@@ -48,7 +49,7 @@ class DCacheCoreReq_np extends Bundle{
 }
 
 class DCacheCoreRsp_np extends Bundle{
-  val instrId = UInt(log2Up(lsu_nMshrEntry).W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val data = Vec(num_thread, UInt(xLen.W))
 //  val ctrl = new Bundle{
 //    val mem_cmd = UInt(2.W)
@@ -65,7 +66,7 @@ class ShareMemPerLaneAddr_np extends Bundle{
 }
 class ShareMemCoreReq_np extends Bundle{
   //val ctrlAddr = new Bundle{
-  val instrId = UInt(log2Up(lsu_nMshrEntry).W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val isWrite = Bool()//Vec(NLanes, Bool())
   //val tag = UInt(dcache_TagBits.W)
   val setIdx = UInt(log2Ceil(sharedmem_depth).W)
@@ -74,7 +75,7 @@ class ShareMemCoreReq_np extends Bundle{
 }
 
 class ShareMemCoreRsp_np extends Bundle{
-  val instrId = UInt(log2Up(lsu_nMshrEntry).W)
+  val instrId = UInt(lsu_mem_instr_id_bits.W)
   val data = Vec(num_thread, UInt(xLen.W))
   val activeMask = Vec(num_thread, Bool())//UInt(NLanes.W)
 }
@@ -111,6 +112,7 @@ object ByteExtract{
 }
 
 class AddrCalculate(val sharedmemory_maxsize: UInt = 4096.U(32.W)) extends Module{
+  private val subcoreIdWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
   val io = IO(new Bundle{
     val from_fifo = Flipped(DecoupledIO(new vExeData))
     val csr_wid = Output(UInt(depth_warp.W))
@@ -118,6 +120,7 @@ class AddrCalculate(val sharedmemory_maxsize: UInt = 4096.U(32.W)) extends Modul
     val csr_numw = Input(UInt(xLen.W))
     val csr_numt = Input(UInt(xLen.W))
     val csr_tid = Input(UInt(xLen.W))
+    val subcore_id = Input(UInt(subcoreIdWidth.W))
     val to_mshr = DecoupledIO(new Bundle{
       val tag = new MshrTag
     })
@@ -431,7 +434,8 @@ class AddrCalculate(val sharedmemory_maxsize: UInt = 4096.U(32.W)) extends Modul
 
   if (SPIKE_OUTPUT) {
   when(state === s_save && io.to_mshr.fire && reg_save.ctrl.mem) {
-    val common_prefix = p"sm ${reg_save.ctrl.spike_info.get.sm_id} warp ${Decimal(reg_save.ctrl.wid)} 0x${Hexadecimal(reg_save.ctrl.spike_info.get.pc)} 0x${Hexadecimal(reg_save.ctrl.spike_info.get.inst)} "
+    val globalWid = PipeSubcoreHelpers.internalWid(io.subcore_id, reg_save.ctrl.wid)
+    val common_prefix = p"sm ${reg_save.ctrl.spike_info.get.sm_id} warp ${Decimal(globalWid)} 0x${Hexadecimal(reg_save.ctrl.spike_info.get.pc)} 0x${Hexadecimal(reg_save.ctrl.spike_info.get.inst)} "
     when(!reg_save.ctrl.isvec) {
       when(reg_save.ctrl.mem_cmd === IDecode.M_XRD) {
         printf(common_prefix + p"lsu.r x ${reg_save.ctrl.reg_idxw} op ${reg_save.ctrl.mop} @ ${Hexadecimal(reg_save.in1(0))}+${Hexadecimal(reg_save.in2(0))}\n")
@@ -542,9 +546,11 @@ class LSU2WB extends Module{
     }
   })
 }
-class LSUexe() extends Module{
+@instantiable
+class LSUexe(val nWarps: Int = num_warp) extends Module{
+  private val subcoreIdWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
 // default size: 128 * (num_thread=8) * (xlen/8=4) = 4KByte
-  val io = IO(new Bundle{
+  @public val io = IO(new Bundle{
     val lsu_req = Flipped(DecoupledIO(new vExeData()))
     val dcache_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np()))
     //val lsu_rsp = DecoupledIO(new WriteBackControl())
@@ -552,7 +558,7 @@ class LSUexe() extends Module{
     val dcache_req = DecoupledIO(new DCacheCoreReq_np())
     val shared_req = DecoupledIO(new ShareMemCoreReq_np())
     val shared_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
-    val fence_end = Output(UInt(num_warp.W))
+    val fence_end = Output(UInt(nWarps.W))
     val flush_dcache = Flipped(DecoupledIO(Bool()))
 
     val csr_wid = Output(UInt(depth_warp.W))
@@ -560,6 +566,7 @@ class LSUexe() extends Module{
     val csr_numw = Input(UInt(xLen.W))
     val csr_numt = Input(UInt(xLen.W))
     val csr_tid = Input(UInt(xLen.W))
+    val subcore_id = Input(UInt(subcoreIdWidth.W))
   })
   val sharedmemory_addr_max = sharemem_size.U(32.W)
   //val sharedmemory = Module(new SharedMemoryV2(nSharedMemoryEntry, num_thread, xLen, lsu_nMshrEntry)) // default: 128
@@ -568,6 +575,7 @@ class LSUexe() extends Module{
   InputFIFO.io.enq <> io.lsu_req
 
   val AddrCalc = Module(new AddrCalculate(sharedmemory_addr_max))
+  AddrCalc.io.subcore_id := io.subcore_id
   AddrCalc.io.from_fifo <> InputFIFO.io.deq
   io.dcache_req <> AddrCalc.io.to_dcache
   io.shared_req <> AddrCalc.io.to_shared
@@ -585,7 +593,7 @@ class LSUexe() extends Module{
   AddrCalc.io.idx_entry:=Coalscer.io.idx_entry
   io.lsu_rsp <> Coalscer.io.to_pipe
 
-  val shiftBoard=VecInit(Seq.fill(num_warp)(Module(new ShiftBoard(lsu_num_entry_each_warp)).io))
+  val shiftBoard=VecInit(Seq.fill(nWarps)(Module(new ShiftBoard(lsu_num_entry_each_warp)).io))
   shiftBoard.zipWithIndex.foreach{case(a,b)=> {
     a.left:=io.lsu_req.fire & io.lsu_req.bits.ctrl.wid===b.asUInt
     a.right:=io.lsu_rsp.fire & io.lsu_rsp.bits.tag.warp_id===b.asUInt

--- a/ventus/src/pipeline/PCcontrol.scala
+++ b/ventus/src/pipeline/PCcontrol.scala
@@ -11,10 +11,12 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
+@instantiable
 class PCcontrol() extends Module{
-  val io=IO(new Bundle{
+  @public val io=IO(new Bundle{
     val New_PC=Input(UInt(32.W))
     val PC_replay=Input(Bool())
     val PC_src=Input(UInt(2.W))

--- a/ventus/src/pipeline/PipeBackendFabric.scala
+++ b/ventus/src/pipeline/PipeBackendFabric.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.util._
+
+class SubcoreWritebackFabricIO extends Bundle {
+  val alu_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val fpu_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val lsu_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val csr_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val sfu_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val mul_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+
+  val valu_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val fpu_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val lsu_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val sfu_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val mul_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val tc_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val csr_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+
+  val write_scalar = DecoupledIO(new WriteScalarCtrl)
+  val write_vec = DecoupledIO(new WriteVecCtrl)
+}
+
+/** Preserves the existing 6 scalar / 7 vector slot contract within one subcore. */
+class SubcoreWritebackFabric(subcoreId: Int) extends Module {
+  val io = IO(new SubcoreWritebackFabricIO)
+  private val wb = Module(new Writeback(6, 7, subcoreId))
+
+  private val scalarInputs = Seq(
+    io.alu_scalar,
+    io.fpu_scalar,
+    io.lsu_scalar,
+    io.csr_scalar,
+    io.sfu_scalar,
+    io.mul_scalar
+  )
+  private val vectorInputs = Seq(
+    io.valu_vec,
+    io.fpu_vec,
+    io.lsu_vec,
+    io.sfu_vec,
+    io.mul_vec,
+    io.tc_vec,
+    io.csr_vec
+  )
+
+  scalarInputs.zip(wb.io.in_x).foreach { case (in, slot) => slot <> in }
+  vectorInputs.zip(wb.io.in_v).foreach { case (in, slot) => slot <> in }
+  io.write_scalar <> wb.io.out_x
+  io.write_vec <> wb.io.out_v
+}

--- a/ventus/src/pipeline/PipeExecutionResultFabric.scala
+++ b/ventus/src/pipeline/PipeExecutionResultFabric.scala
@@ -1,0 +1,26 @@
+package pipeline
+
+import chisel3._
+import chisel3.util._
+
+class PipeExecutionResultFabricIO(numSubcores: Int) extends Bundle {
+  val aluBranchIn = Flipped(Vec(numSubcores, DecoupledIO(new BranchCtrl)))
+  val lifecycleIn = Flipped(Vec(numSubcores, DecoupledIO(new warpSchedulerExeData)))
+
+  val aluBranchOut = DecoupledIO(new BranchCtrl)
+  val lifecycleOut = DecoupledIO(new warpSchedulerExeData)
+}
+
+/** Keeps all cross-subcore execution arbitration behind one stable hierarchy. */
+class PipeExecutionResultFabric(numSubcores: Int) extends Module {
+  val io = IO(new PipeExecutionResultFabricIO(numSubcores))
+
+  private def arbitrate[T <: Data](in: Vec[DecoupledIO[T]], out: DecoupledIO[T], gen: T): Unit = {
+    val arb = Module(new Arbiter(gen, numSubcores))
+    arb.io.in <> in
+    out <> arb.io.out
+  }
+
+  arbitrate(io.aluBranchIn, io.aluBranchOut, new BranchCtrl)
+  arbitrate(io.lifecycleIn, io.lifecycleOut, new warpSchedulerExeData)
+}

--- a/ventus/src/pipeline/PipeSharedLsuFabric.scala
+++ b/ventus/src/pipeline/PipeSharedLsuFabric.scala
@@ -1,0 +1,141 @@
+package pipeline
+
+import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
+import chisel3.util._
+
+class PipeSharedLsuSourceIO extends Bundle {
+  val dcache_req = Flipped(DecoupledIO(new DCacheCoreReq_np))
+  val dcache_rsp = DecoupledIO(new DCacheCoreRsp_np)
+  val shared_req = Flipped(DecoupledIO(new ShareMemCoreReq_np))
+  val shared_rsp = DecoupledIO(new DCacheCoreRsp_np)
+  val lsu_rsp = Flipped(DecoupledIO(new MSHROutput))
+}
+
+class PipeSharedLsuFabricIO(numSources: Int) extends Bundle {
+  val subcore = Vec(numSources, new PipeSharedLsuSourceIO)
+
+  val sm_dcache_req = DecoupledIO(new DCacheCoreReq_np)
+  val sm_dcache_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val sm_shared_req = DecoupledIO(new ShareMemCoreReq_np)
+  val sm_shared_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val lsu2wb_lsu_rsp = DecoupledIO(new MSHROutput)
+}
+
+@instantiable
+class PipeSharedLsuFabric(numSources: Int, sourceWidth: Int, localInstrIdWidth: Int) extends Module {
+  @public val io = IO(new PipeSharedLsuFabricIO(numSources))
+
+  require(numSources >= 1)
+
+  private val dcacheInstrIdWidth = (new DCacheCoreReq_np).instrId.getWidth
+
+  private def encodeInstrId(source: UInt, localInstrId: UInt): UInt = {
+    val encoded = Wire(UInt(dcacheInstrIdWidth.W))
+    encoded := Cat(source(sourceWidth - 1, 0), localInstrId(localInstrIdWidth - 1, 0))
+    encoded
+  }
+
+  private def decodeSource(fabricInstrId: UInt): UInt =
+    fabricInstrId(sourceWidth + localInstrIdWidth - 1, localInstrIdWidth)
+
+  private def decodeLocalInstrId(fabricInstrId: UInt): UInt =
+    fabricInstrId(localInstrIdWidth - 1, 0)
+
+  for (source <- 0 until numSources) {
+    io.subcore(source).dcache_req.ready := false.B
+    io.subcore(source).dcache_rsp.valid := false.B
+    io.subcore(source).dcache_rsp.bits := 0.U.asTypeOf(new DCacheCoreRsp_np)
+    io.subcore(source).shared_req.ready := false.B
+    io.subcore(source).shared_rsp.valid := false.B
+    io.subcore(source).shared_rsp.bits := 0.U.asTypeOf(new DCacheCoreRsp_np)
+    io.subcore(source).lsu_rsp.ready := false.B
+  }
+
+  val dcacheReqArb = Module(new RRArbiter(new DCacheCoreReq_np, numSources))
+  val sharedReqArb = Module(new RRArbiter(new ShareMemCoreReq_np, numSources))
+  val lsuRspArb = Module(new RRArbiter(new MSHROutput, numSources))
+
+  for (source <- 0 until numSources) {
+    val sourceId = source.U(sourceWidth.W)
+    val dcacheReq = Wire(new DCacheCoreReq_np)
+    val sharedReq = Wire(new ShareMemCoreReq_np)
+    dcacheReq := io.subcore(source).dcache_req.bits
+    sharedReq := io.subcore(source).shared_req.bits
+    dcacheReq.instrId := encodeInstrId(sourceId, io.subcore(source).dcache_req.bits.instrId)
+    sharedReq.instrId := encodeInstrId(sourceId, io.subcore(source).shared_req.bits.instrId)
+
+    dcacheReqArb.io.in(source).valid := io.subcore(source).dcache_req.valid
+    dcacheReqArb.io.in(source).bits := dcacheReq
+    io.subcore(source).dcache_req.ready := dcacheReqArb.io.in(source).ready
+    sharedReqArb.io.in(source).valid := io.subcore(source).shared_req.valid
+    sharedReqArb.io.in(source).bits := sharedReq
+    io.subcore(source).shared_req.ready := sharedReqArb.io.in(source).ready
+    val restoredLsuRsp = Wire(new MSHROutput)
+    restoredLsuRsp := io.subcore(source).lsu_rsp.bits
+    restoredLsuRsp.tag.warp_id :=
+      PipeSubcoreHelpers.internalWid(source, io.subcore(source).lsu_rsp.bits.tag.warp_id)
+    lsuRspArb.io.in(source).valid := io.subcore(source).lsu_rsp.valid
+    lsuRspArb.io.in(source).bits := restoredLsuRsp
+    io.subcore(source).lsu_rsp.ready := lsuRspArb.io.in(source).ready
+  }
+
+  io.sm_dcache_req <> dcacheReqArb.io.out
+  io.sm_shared_req <> sharedReqArb.io.out
+
+  when(dcacheReqArb.io.out.valid) {
+    assert(dcacheReqArb.io.chosen < numSources.U)
+  }
+  when(sharedReqArb.io.out.valid) {
+    assert(sharedReqArb.io.chosen < numSources.U)
+  }
+  when(lsuRspArb.io.out.valid) {
+    assert(lsuRspArb.io.chosen < numSources.U)
+  }
+  assert(PopCount(dcacheReqArb.io.in.map(_.fire)) <= 1.U)
+  assert(PopCount(sharedReqArb.io.in.map(_.fire)) <= 1.U)
+  assert(PopCount(lsuRspArb.io.in.map(_.fire)) <= 1.U)
+
+  val lsuRspOut = Module(new Queue(new MSHROutput, 2))
+  lsuRspOut.io.enq <> lsuRspArb.io.out
+  io.lsu2wb_lsu_rsp <> lsuRspOut.io.deq
+
+  val dcacheRspIn = Module(new Queue(new DCacheCoreRsp_np, 4))
+  val sharedRspIn = Module(new Queue(new DCacheCoreRsp_np, 4))
+  dcacheRspIn.io.enq <> io.sm_dcache_rsp
+  sharedRspIn.io.enq <> io.sm_shared_rsp
+
+  val dcacheRspSource = decodeSource(dcacheRspIn.io.deq.bits.instrId)
+  val dcacheRspLocalInstrId = decodeLocalInstrId(dcacheRspIn.io.deq.bits.instrId)
+  val sharedRspSource = decodeSource(sharedRspIn.io.deq.bits.instrId)
+  val sharedRspLocalInstrId = decodeLocalInstrId(sharedRspIn.io.deq.bits.instrId)
+  val dcacheRsp = Wire(new DCacheCoreRsp_np)
+  val sharedRsp = Wire(new DCacheCoreRsp_np)
+  dcacheRsp := dcacheRspIn.io.deq.bits
+  sharedRsp := sharedRspIn.io.deq.bits
+  dcacheRsp.instrId := dcacheRspLocalInstrId
+  sharedRsp.instrId := sharedRspLocalInstrId
+
+  val dcacheRspReady = Wire(Vec(numSources, Bool()))
+  val sharedRspReady = Wire(Vec(numSources, Bool()))
+  val dcacheRspSourceMatch = Wire(Vec(numSources, Bool()))
+  val sharedRspSourceMatch = Wire(Vec(numSources, Bool()))
+  for (source <- 0 until numSources) {
+    val sourceId = source.U(sourceWidth.W)
+    dcacheRspSourceMatch(source) := dcacheRspSource === sourceId
+    io.subcore(source).dcache_rsp.valid := dcacheRspIn.io.deq.valid && dcacheRspSourceMatch(source)
+    io.subcore(source).dcache_rsp.bits := dcacheRsp
+    dcacheRspReady(source) := io.subcore(source).dcache_rsp.ready
+    sharedRspSourceMatch(source) := sharedRspSource === sourceId
+    io.subcore(source).shared_rsp.valid := sharedRspIn.io.deq.valid && sharedRspSourceMatch(source)
+    io.subcore(source).shared_rsp.bits := sharedRsp
+    sharedRspReady(source) := io.subcore(source).shared_rsp.ready
+  }
+
+  dcacheRspIn.io.deq.ready := Mux1H((0 until numSources).map { source =>
+    dcacheRspSourceMatch(source) -> dcacheRspReady(source)
+  })
+  sharedRspIn.io.deq.ready := Mux1H((0 until numSources).map { source =>
+    sharedRspSourceMatch(source) -> sharedRspReady(source)
+  })
+}

--- a/ventus/src/pipeline/PipeSubcoreHelpers.scala
+++ b/ventus/src/pipeline/PipeSubcoreHelpers.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.util._
+import top.parameters._
+
+object PipeSubcoreHelpers {
+  def globalWarpIndex(sc: Int, local: Int): Int = {
+    if (num_warp_per_subcore == 1) sc else (local << subcore_sel_bits) | sc
+  }
+
+  def localWidValue(internalWid: UInt): UInt = {
+    if (num_warp_per_subcore == 1) 0.U(1.W)
+    else internalWid(depth_warp - 1, subcore_sel_bits)
+  }
+
+  def subcoreValue(internalWid: UInt): UInt = {
+    if (subcore_sel_bits == 0) 0.U(1.W)
+    else internalWid(subcore_sel_bits - 1, 0)
+  }
+
+  def internalWid(sc: Int, localWid: UInt): UInt = {
+    val localDepthWarp =
+      if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+    if (num_warp_per_subcore == 1) sc.U(depth_warp.W)
+    else Cat(localWid(localDepthWarp - 1, 0), sc.U(subcore_sel_bits.W))
+  }
+
+  def internalWid(sc: UInt, localWid: UInt): UInt = {
+    val localDepthWarp =
+      if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+    if (num_warp_per_subcore == 1) sc(depth_warp - 1, 0)
+    else if (subcore_sel_bits == 0) localWid(localDepthWarp - 1, 0)
+    else Cat(localWid(localDepthWarp - 1, 0), sc(subcore_sel_bits - 1, 0))
+  }
+}

--- a/ventus/src/pipeline/ScoreboardEventCollector.scala
+++ b/ventus/src/pipeline/ScoreboardEventCollector.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.util._
+import top.parameters._
+
+class ScoreboardSubcoreEvents extends Bundle {
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+
+  val branch_fire = Bool()
+  val branch_wid = UInt(localDepthWarp.W)
+  val simt_complete_fire = Bool()
+  val simt_complete_wid = UInt(localDepthWarp.W)
+  val op_col_v_in_fire = Bool()
+  val op_col_v_in_wid = UInt(localDepthWarp.W)
+  val op_col_v_out_fire = Bool()
+  val op_col_v_out_wid = UInt(localDepthWarp.W)
+  val op_col_x_in_fire = Bool()
+  val op_col_x_in_wid = UInt(localDepthWarp.W)
+  val op_col_x_out_fire = Bool()
+  val op_col_x_out_wid = UInt(localDepthWarp.W)
+  val endprg_fire = Bool()
+  val endprg_wid = UInt(localDepthWarp.W)
+}

--- a/ventus/src/pipeline/SubcoreBackendSlice.scala
+++ b/ventus/src/pipeline/SubcoreBackendSlice.scala
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.experimental.hierarchy.{Instantiate, instantiable, public}
+import chisel3.util._
+import top.parameters._
+
+// SubcoreBackendSlice owns the subcore-local execution slices that have been
+// validated so far. DCache/shared memory and LSU2WB remain SM-shared; final
+// writeback arbitration is local to each subcore just outside this slice.
+
+class SubcoreBackendSliceIO extends Bundle {
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+  private val subcoreIdWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
+
+  val subcore_id = Input(UInt(subcoreIdWidth.W))
+
+  val frontend_control_v = Flipped(DecoupledIO(new CtrlSigs))
+  val frontend_control_x = Flipped(DecoupledIO(new CtrlSigs))
+
+  val write_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val write_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+
+  val branch_out = DecoupledIO(new BranchCtrl)
+  val simt_complete = ValidIO(UInt(localDepthWarp.W))
+  val warp_lifecycle = DecoupledIO(new warpSchedulerExeData)
+  val warp_init = Input(ValidIO(new warpReqData))
+  val csr_scalar = DecoupledIO(new WriteScalarCtrl)
+  val csr_vec = DecoupledIO(new WriteVecCtrl)
+
+  val lsu_dcache_req = DecoupledIO(new DCacheCoreReq_np)
+  val lsu_dcache_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val lsu_shared_req = DecoupledIO(new ShareMemCoreReq_np)
+  val lsu_shared_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val lsu_result_rsp = DecoupledIO(new MSHROutput)
+  val flush_dcache = Flipped(DecoupledIO(Bool()))
+  val lsu_fence_end = Output(UInt(num_warp_per_subcore.W))
+
+  val compute_alu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val compute_fpu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val compute_fpu_vec = DecoupledIO(new WriteVecCtrl)
+  val compute_sfu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val compute_sfu_vec = DecoupledIO(new WriteVecCtrl)
+  val compute_valu_vec = DecoupledIO(new WriteVecCtrl)
+  val compute_mul_scalar = DecoupledIO(new WriteScalarCtrl)
+  val compute_mul_vec = DecoupledIO(new WriteVecCtrl)
+  val compute_tc_vec = DecoupledIO(new WriteVecCtrl)
+
+  val scoreboard = Output(new ScoreboardSubcoreEvents)
+}
+
+class SubcoreScalarExecSliceIO extends Bundle {
+  val issue_salu = Input(ValidIO(new sExeData))
+  val issue_salu_ready = Output(Bool())
+  val issue_csr = Input(ValidIO(new csrExeData))
+  val issue_csr_ready = Output(Bool())
+  val csr_rm_wid = Input(Vec(3, UInt(depth_warp.W)))
+  val csr_cta = Input(ValidIO(new warpReqData))
+  val csr_lsu_wid = Input(UInt(depth_warp.W))
+  val csr_simt_wid = Input(UInt(depth_warp.W))
+
+  val alu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val alu_branch = DecoupledIO(new BranchCtrl)
+  val csr_scalar = DecoupledIO(new WriteScalarCtrl)
+  val csr_vec = DecoupledIO(new WriteVecCtrl)
+
+  val rm = Output(Vec(3, UInt(3.W)))
+  val sgpr_base = Output(Vec(num_warp_per_subcore, UInt((SGPR_ID_WIDTH + 1).W)))
+  val vgpr_base = Output(Vec(num_warp_per_subcore, UInt((VGPR_ID_WIDTH + 1).W)))
+  val lsu_tid = Output(UInt(xLen.W))
+  val lsu_pds = Output(UInt(xLen.W))
+  val lsu_numw = Output(UInt(xLen.W))
+  val lsu_numt = Output(UInt(xLen.W))
+  val simt_rpc = Output(UInt(xLen.W))
+}
+
+@instantiable
+class SubcoreScalarExecSlice extends Module {
+  @public val io = IO(new SubcoreScalarExecSliceIO)
+
+  private val scalarAlu = Instantiate(new ALUexe)
+  private val csr = Instantiate(new CSRexe(num_warp_per_subcore))
+
+  scalarAlu.io.in.valid := io.issue_salu.valid
+  scalarAlu.io.in.bits := io.issue_salu.bits
+  io.issue_salu_ready := scalarAlu.io.in.ready
+  io.alu_scalar.valid := scalarAlu.io.out.valid
+  io.alu_scalar.bits := scalarAlu.io.out.bits
+  scalarAlu.io.out.ready := io.alu_scalar.ready
+  io.alu_branch.valid := scalarAlu.io.out2br.valid
+  io.alu_branch.bits := scalarAlu.io.out2br.bits
+  scalarAlu.io.out2br.ready := io.alu_branch.ready
+
+  csr.io.in.valid := io.issue_csr.valid
+  csr.io.in.bits := io.issue_csr.bits
+  io.issue_csr_ready := csr.io.in.ready
+  csr.io.rm_wid := io.csr_rm_wid
+  csr.io.CTA2csr := io.csr_cta
+  csr.io.lsu_wid := io.csr_lsu_wid
+  csr.io.simt_wid := io.csr_simt_wid
+  io.csr_scalar.valid := csr.io.out.valid
+  io.csr_scalar.bits := csr.io.out.bits
+  csr.io.out.ready := io.csr_scalar.ready
+  io.csr_vec.valid := csr.io.out_v.valid
+  io.csr_vec.bits := csr.io.out_v.bits
+  csr.io.out_v.ready := io.csr_vec.ready
+
+  io.rm := csr.io.rm
+  io.sgpr_base := VecInit(csr.io.sgpr_base.take(num_warp_per_subcore))
+  io.vgpr_base := VecInit(csr.io.vgpr_base.take(num_warp_per_subcore))
+  io.lsu_tid := csr.io.lsu_tid
+  io.lsu_pds := csr.io.lsu_pds
+  io.lsu_numw := csr.io.lsu_numw
+  io.lsu_numt := csr.io.lsu_numt
+  io.simt_rpc := csr.io.simt_rpc
+}
+
+class SubcoreMemoryExecSliceIO extends Bundle {
+  private val subcoreIdWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
+
+  val subcore_id = Input(UInt(subcoreIdWidth.W))
+  val issue_lsu = Input(ValidIO(new vExeData))
+  val issue_lsu_ready = Output(Bool())
+
+  val lsu_dcache_req = DecoupledIO(new DCacheCoreReq_np)
+  val lsu_dcache_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val lsu_shared_req = DecoupledIO(new ShareMemCoreReq_np)
+  val lsu_shared_rsp = Flipped(DecoupledIO(new DCacheCoreRsp_np))
+  val lsu_result_rsp = DecoupledIO(new MSHROutput)
+  val flush_dcache = Flipped(DecoupledIO(Bool()))
+  val fence_end = Output(UInt(num_warp_per_subcore.W))
+
+  val csr_wid = Output(UInt(depth_warp.W))
+  val csr_tid = Input(UInt(xLen.W))
+  val csr_pds = Input(UInt(xLen.W))
+  val csr_numw = Input(UInt(xLen.W))
+  val csr_numt = Input(UInt(xLen.W))
+}
+
+@instantiable
+class SubcoreMemoryExecSlice extends Module {
+  @public val io = IO(new SubcoreMemoryExecSliceIO)
+
+  private val lsu = Instantiate(new LSUexe(num_warp_per_subcore))
+  lsu.io.subcore_id := io.subcore_id
+
+  lsu.io.lsu_req.valid := io.issue_lsu.valid
+  lsu.io.lsu_req.bits := io.issue_lsu.bits
+  io.issue_lsu_ready := lsu.io.lsu_req.ready
+
+  io.lsu_dcache_req.valid := lsu.io.dcache_req.valid
+  io.lsu_dcache_req.bits := lsu.io.dcache_req.bits
+  lsu.io.dcache_req.ready := io.lsu_dcache_req.ready
+  lsu.io.dcache_rsp.valid := io.lsu_dcache_rsp.valid
+  lsu.io.dcache_rsp.bits := io.lsu_dcache_rsp.bits
+  io.lsu_dcache_rsp.ready := lsu.io.dcache_rsp.ready
+  io.lsu_shared_req.valid := lsu.io.shared_req.valid
+  io.lsu_shared_req.bits := lsu.io.shared_req.bits
+  lsu.io.shared_req.ready := io.lsu_shared_req.ready
+  lsu.io.shared_rsp.valid := io.lsu_shared_rsp.valid
+  lsu.io.shared_rsp.bits := io.lsu_shared_rsp.bits
+  io.lsu_shared_rsp.ready := lsu.io.shared_rsp.ready
+  io.lsu_result_rsp.valid := lsu.io.lsu_rsp.valid
+  io.lsu_result_rsp.bits := lsu.io.lsu_rsp.bits
+  lsu.io.lsu_rsp.ready := io.lsu_result_rsp.ready
+  lsu.io.flush_dcache.valid := io.flush_dcache.valid
+  lsu.io.flush_dcache.bits := io.flush_dcache.bits
+  io.flush_dcache.ready := lsu.io.flush_dcache.ready
+
+  io.fence_end := lsu.io.fence_end
+  io.csr_wid := lsu.io.csr_wid
+  lsu.io.csr_pds := io.csr_pds
+  lsu.io.csr_tid := io.csr_tid
+  lsu.io.csr_numw := io.csr_numw
+  lsu.io.csr_numt := io.csr_numt
+}
+
+class SubcoreVectorExecSliceIO extends Bundle {
+  val issue_fpu = Input(ValidIO(new vExeData))
+  val issue_fpu_ready = Output(Bool())
+  val issue_sfu = Input(ValidIO(new vExeData))
+  val issue_sfu_ready = Output(Bool())
+  val issue_tc = Input(ValidIO(new vExeData))
+  val issue_tc_ready = Output(Bool())
+
+  val rm = Input(Vec(3, UInt(3.W)))
+
+  val fpu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val fpu_vec = DecoupledIO(new WriteVecCtrl)
+  val sfu_scalar = DecoupledIO(new WriteScalarCtrl)
+  val sfu_vec = DecoupledIO(new WriteVecCtrl)
+  val tc_vec = DecoupledIO(new WriteVecCtrl)
+}
+
+@instantiable
+class SubcoreVectorExecSlice extends Module {
+  @public val io = IO(new SubcoreVectorExecSliceIO)
+
+  private val fpu = Instantiate(new FPUexe(num_thread, num_lane))
+  private val sfu = Instantiate(new SFUexe)
+  private val tensorcore = Instantiate(new vTCexe)
+
+  fpu.io.in.valid := io.issue_fpu.valid
+  fpu.io.in.bits := io.issue_fpu.bits
+  fpu.io.rm := Mux(fpu.io.in.bits.ctrl.force_rm_rtz, RoundingMode.RTZ, io.rm(0))
+  io.issue_fpu_ready := fpu.io.in.ready
+
+  sfu.io.in.valid := io.issue_sfu.valid
+  sfu.io.in.bits := io.issue_sfu.bits
+  sfu.io.rm := io.rm(1)
+  io.issue_sfu_ready := sfu.io.in.ready
+
+  tensorcore.io.in.valid := io.issue_tc.valid
+  tensorcore.io.in.bits := io.issue_tc.bits
+  tensorcore.io.rm := io.rm(2)
+  io.issue_tc_ready := tensorcore.io.in.ready
+
+  // Slice-local execution outputs return to pipe.scala's WB fabric; this slice
+  // does not own final writeback arbitration.
+  io.fpu_scalar.valid := fpu.io.out_x.valid
+  io.fpu_scalar.bits := fpu.io.out_x.bits
+  fpu.io.out_x.ready := io.fpu_scalar.ready
+  io.fpu_vec.valid := fpu.io.out_v.valid
+  io.fpu_vec.bits := fpu.io.out_v.bits
+  fpu.io.out_v.ready := io.fpu_vec.ready
+  io.sfu_scalar.valid := sfu.io.out_x.valid
+  io.sfu_scalar.bits := sfu.io.out_x.bits
+  sfu.io.out_x.ready := io.sfu_scalar.ready
+  io.sfu_vec.valid := sfu.io.out_v.valid
+  io.sfu_vec.bits := sfu.io.out_v.bits
+  sfu.io.out_v.ready := io.sfu_vec.ready
+  io.tc_vec.valid := tensorcore.io.out_v.valid
+  io.tc_vec.bits := tensorcore.io.out_v.bits
+  tensorcore.io.out_v.ready := io.tc_vec.ready
+}
+
+class SubcoreIssueOperandIO extends Bundle {
+  private val localDepthWarp = if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+  val control_x = Flipped(DecoupledIO(new CtrlSigs))
+  val control_v = Flipped(DecoupledIO(new CtrlSigs))
+  val write_scalar = Flipped(DecoupledIO(new WriteScalarCtrl))
+  val write_vec = Flipped(DecoupledIO(new WriteVecCtrl))
+  val sgpr_base = Input(Vec(num_warp_per_subcore, UInt((SGPR_ID_WIDTH + 1).W)))
+  val vgpr_base = Input(Vec(num_warp_per_subcore, UInt((VGPR_ID_WIDTH + 1).W)))
+  val simt_mask = Input(UInt(num_thread.W))
+  val salu = DecoupledIO(new sExeData)
+  val csr = DecoupledIO(new csrExeData)
+  val lifecycle = DecoupledIO(new warpSchedulerExeData)
+  val valu = DecoupledIO(new vExeData)
+  val fpu = DecoupledIO(new vExeData)
+  val sfu = DecoupledIO(new vExeData)
+  val tc = DecoupledIO(new vExeData)
+  val lsu = DecoupledIO(new vExeData)
+  val mul = DecoupledIO(new vExeData)
+  val simt = DecoupledIO(new simtExeData)
+  val op_col_x_in_fire = Output(Bool())
+  val op_col_x_in_wid = Output(UInt(localDepthWarp.W))
+  val op_col_x_out_fire = Output(Bool())
+  val op_col_x_out_wid = Output(UInt(localDepthWarp.W))
+  val op_col_v_in_fire = Output(Bool())
+  val op_col_v_in_wid = Output(UInt(localDepthWarp.W))
+  val op_col_v_out_fire = Output(Bool())
+  val op_col_v_out_wid = Output(UInt(localDepthWarp.W))
+}
+
+@instantiable
+class SubcoreIssueOperand extends Module {
+  @public val io = IO(new SubcoreIssueOperandIO)
+  private val oc = Instantiate(new operandCollector(num_warp_per_subcore))
+  private val issueX = Instantiate(new Issue)
+  private val issueV = Instantiate(new Issue)
+
+  oc.io.controlX.valid := io.control_x.valid; oc.io.controlX.bits := io.control_x.bits; io.control_x.ready := oc.io.controlX.ready
+  oc.io.controlV.valid := io.control_v.valid; oc.io.controlV.bits := io.control_v.bits; io.control_v.ready := oc.io.controlV.ready
+  oc.io.writeScalarCtrl.valid := io.write_scalar.valid; oc.io.writeScalarCtrl.bits := io.write_scalar.bits; io.write_scalar.ready := oc.io.writeScalarCtrl.ready
+  oc.io.writeVecCtrl.valid := io.write_vec.valid; oc.io.writeVecCtrl.bits := io.write_vec.bits; io.write_vec.ready := oc.io.writeVecCtrl.ready
+  oc.io.sgpr_base := io.sgpr_base
+  oc.io.vgpr_base := io.vgpr_base
+
+  issueX.io.in.valid := oc.io.out(1).valid
+  issueX.io.in.bits.ctrl := oc.io.out(1).bits.control
+  issueX.io.in.bits.in1 := oc.io.out(1).bits.alu_src1
+  issueX.io.in.bits.in2 := oc.io.out(1).bits.alu_src2
+  issueX.io.in.bits.in3 := oc.io.out(1).bits.alu_src3
+  issueX.io.in.bits.mask.foreach(_ := true.B)
+  oc.io.out(1).ready := issueX.io.in.ready
+  issueV.io.in.valid := oc.io.out(0).valid
+  issueV.io.in.bits.ctrl := oc.io.out(0).bits.control
+  issueV.io.in.bits.in1 := oc.io.out(0).bits.alu_src1
+  issueV.io.in.bits.in2 := oc.io.out(0).bits.alu_src2
+  issueV.io.in.bits.in3 := oc.io.out(0).bits.alu_src3
+  issueV.io.in.bits.mask := VecInit((0 until num_thread).map(i => oc.io.out(0).bits.mask(i) & io.simt_mask(i)))
+  oc.io.out(0).ready := issueV.io.in.ready
+
+  def forward[T <: Data](dst: DecoupledIO[T], src: DecoupledIO[T]): Unit = {
+    dst.valid := src.valid; dst.bits := src.bits; src.ready := dst.ready
+  }
+  forward(io.salu, issueX.io.out_sALU)
+  forward(io.csr, issueX.io.out_CSR)
+  forward(io.lifecycle, issueX.io.out_warpscheduler)
+  issueX.io.out_vALU.ready := false.B; issueX.io.out_vFPU.ready := false.B
+  issueX.io.out_LSU.ready := false.B; issueX.io.out_SFU.ready := false.B
+  issueX.io.out_SIMT.ready := false.B; issueX.io.out_MUL.ready := false.B; issueX.io.out_TC.ready := false.B
+  forward(io.valu, issueV.io.out_vALU)
+  forward(io.fpu, issueV.io.out_vFPU)
+  forward(io.sfu, issueV.io.out_SFU)
+  forward(io.tc, issueV.io.out_TC)
+  forward(io.lsu, issueV.io.out_LSU)
+  forward(io.mul, issueV.io.out_MUL)
+  forward(io.simt, issueV.io.out_SIMT)
+  issueV.io.out_sALU.ready := false.B; issueV.io.out_CSR.ready := false.B
+  issueV.io.out_warpscheduler.ready := false.B
+
+  io.op_col_x_in_fire := oc.io.controlX.fire; io.op_col_x_in_wid := oc.io.controlX.bits.wid
+  io.op_col_x_out_fire := oc.io.out(1).fire; io.op_col_x_out_wid := oc.io.out(1).bits.control.wid
+  io.op_col_v_in_fire := oc.io.controlV.fire; io.op_col_v_in_wid := oc.io.controlV.bits.wid
+  io.op_col_v_out_fire := oc.io.out(0).fire; io.op_col_v_out_wid := oc.io.out(0).bits.control.wid
+}
+
+class SubcoreControlFlowIO extends Bundle {
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+
+  val simt_issue = Flipped(DecoupledIO(new simtExeData))
+  val valu_mask = Flipped(DecoupledIO(new vec_alu_bus))
+  val scalar_branch = Flipped(DecoupledIO(new BranchCtrl))
+  val pc_reconv = Input(UInt(xLen.W))
+  val warp_init = Input(Valid(new warpReqData))
+
+  val simt_mask = Output(UInt(num_thread.W))
+  val branch = DecoupledIO(new BranchCtrl)
+  val complete = ValidIO(UInt(localDepthWarp.W))
+}
+
+@instantiable
+class SubcoreControlFlow extends Module {
+  @public val io = IO(new SubcoreControlFlowIO)
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+
+  private val simt = Instantiate(new branch_join(num_thread, num_warp_per_subcore))
+  private val branchBack = Instantiate(new Branch_back)
+
+  simt.io.branch_ctl.valid := io.simt_issue.valid
+  simt.io.branch_ctl.bits := io.simt_issue.bits
+  io.simt_issue.ready := simt.io.branch_ctl.ready
+  simt.io.if_mask.valid := io.valu_mask.valid
+  simt.io.if_mask.bits := io.valu_mask.bits
+  io.valu_mask.ready := simt.io.if_mask.ready
+  branchBack.io.in0.valid := io.scalar_branch.valid
+  branchBack.io.in0.bits := io.scalar_branch.bits
+  io.scalar_branch.ready := branchBack.io.in0.ready
+  branchBack.io.in1 <> simt.io.fetch_ctl
+  io.branch.valid := branchBack.io.out.valid
+  io.branch.bits := branchBack.io.out.bits
+  branchBack.io.out.ready := io.branch.ready
+
+  simt.io.input_wid := io.simt_issue.bits.wid
+  simt.io.pc_reconv.bits := io.pc_reconv
+  simt.io.pc_reconv.valid := io.simt_issue.valid
+  simt.io.initMask.valid := io.warp_init.valid
+  simt.io.initMask.bits.warp_id := io.warp_init.bits.wid
+  simt.io.initMask.bits.thread_mask :=
+    (1.U(num_thread.W) << io.warp_init.bits.CTAdata.dispatch2cu_wf_size_dispatch).asUInt - 1.U
+
+  io.simt_mask := simt.io.out_mask
+  io.complete.valid := simt.io.complete.valid
+  io.complete.bits := simt.io.complete.bits(localDepthWarp - 1, 0)
+}
+
+@instantiable
+class SubcoreBackendSlice extends Module {
+  @public val io = IO(new SubcoreBackendSliceIO)
+  private val localDepthWarp =
+    if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+
+  // Hierarchical subcore backend slices. Writeback/fabric remains outside this
+  // slice so firtool does not see vector execution and arbitration as one block.
+  val scalarExec = Instantiate(new SubcoreScalarExecSlice)
+  val memoryExec = Instantiate(new SubcoreMemoryExecSlice)
+  val vectorExec = Instantiate(new SubcoreVectorExecSlice)
+
+  memoryExec.io.subcore_id := io.subcore_id
+
+  io.lsu_fence_end := memoryExec.io.fence_end
+  scalarExec.io.csr_cta := io.warp_init
+  scalarExec.io.csr_lsu_wid := memoryExec.io.csr_wid
+  io.csr_scalar.valid := scalarExec.io.csr_scalar.valid
+  io.csr_scalar.bits := scalarExec.io.csr_scalar.bits
+  scalarExec.io.csr_scalar.ready := io.csr_scalar.ready
+  io.csr_vec.valid := scalarExec.io.csr_vec.valid
+  io.csr_vec.bits := scalarExec.io.csr_vec.bits
+  scalarExec.io.csr_vec.ready := io.csr_vec.ready
+
+  // DCache, shared memory, and LSU2WB remain SM-level resources.
+  io.lsu_dcache_req.valid := memoryExec.io.lsu_dcache_req.valid
+  io.lsu_dcache_req.bits := memoryExec.io.lsu_dcache_req.bits
+  memoryExec.io.lsu_dcache_req.ready := io.lsu_dcache_req.ready
+  memoryExec.io.lsu_dcache_rsp.valid := io.lsu_dcache_rsp.valid
+  memoryExec.io.lsu_dcache_rsp.bits := io.lsu_dcache_rsp.bits
+  io.lsu_dcache_rsp.ready := memoryExec.io.lsu_dcache_rsp.ready
+  io.lsu_shared_req.valid := memoryExec.io.lsu_shared_req.valid
+  io.lsu_shared_req.bits := memoryExec.io.lsu_shared_req.bits
+  memoryExec.io.lsu_shared_req.ready := io.lsu_shared_req.ready
+  memoryExec.io.lsu_shared_rsp.valid := io.lsu_shared_rsp.valid
+  memoryExec.io.lsu_shared_rsp.bits := io.lsu_shared_rsp.bits
+  io.lsu_shared_rsp.ready := memoryExec.io.lsu_shared_rsp.ready
+  io.lsu_result_rsp.valid := memoryExec.io.lsu_result_rsp.valid
+  io.lsu_result_rsp.bits := memoryExec.io.lsu_result_rsp.bits
+  memoryExec.io.lsu_result_rsp.ready := io.lsu_result_rsp.ready
+  memoryExec.io.flush_dcache.valid := io.flush_dcache.valid
+  memoryExec.io.flush_dcache.bits := io.flush_dcache.bits
+  io.flush_dcache.ready := memoryExec.io.flush_dcache.ready
+  memoryExec.io.csr_pds := scalarExec.io.lsu_pds
+  memoryExec.io.csr_tid := scalarExec.io.lsu_tid
+  memoryExec.io.csr_numw := scalarExec.io.lsu_numw
+  memoryExec.io.csr_numt := scalarExec.io.lsu_numt
+
+  vectorExec.io.rm := scalarExec.io.rm
+  io.compute_alu_scalar.valid := scalarExec.io.alu_scalar.valid
+  io.compute_alu_scalar.bits := scalarExec.io.alu_scalar.bits
+  scalarExec.io.alu_scalar.ready := io.compute_alu_scalar.ready
+  io.compute_fpu_scalar.valid := vectorExec.io.fpu_scalar.valid
+  io.compute_fpu_scalar.bits := vectorExec.io.fpu_scalar.bits
+  vectorExec.io.fpu_scalar.ready := io.compute_fpu_scalar.ready
+  io.compute_fpu_vec.valid := vectorExec.io.fpu_vec.valid
+  io.compute_fpu_vec.bits := vectorExec.io.fpu_vec.bits
+  vectorExec.io.fpu_vec.ready := io.compute_fpu_vec.ready
+  io.compute_sfu_scalar.valid := vectorExec.io.sfu_scalar.valid
+  io.compute_sfu_scalar.bits := vectorExec.io.sfu_scalar.bits
+  vectorExec.io.sfu_scalar.ready := io.compute_sfu_scalar.ready
+  io.compute_sfu_vec.valid := vectorExec.io.sfu_vec.valid
+  io.compute_sfu_vec.bits := vectorExec.io.sfu_vec.bits
+  vectorExec.io.sfu_vec.ready := io.compute_sfu_vec.ready
+  io.compute_tc_vec.valid := vectorExec.io.tc_vec.valid
+  io.compute_tc_vec.bits := vectorExec.io.tc_vec.bits
+  vectorExec.io.tc_vec.ready := io.compute_tc_vec.ready
+
+  // Full subcore backend closure. All wid values in this block are local to
+  // the owning subcore; pipe.scala restores global wid at shared boundaries.
+  val issueOperand = Instantiate(new SubcoreIssueOperand)
+  val localValu = Instantiate(new vALUv2(num_thread, num_lane))
+  val localMul = Instantiate(new vMULv2(num_thread, num_lane))
+  val controlFlow = Instantiate(new SubcoreControlFlow)
+
+  issueOperand.io.control_x.valid := io.frontend_control_x.valid
+  issueOperand.io.control_x.bits := io.frontend_control_x.bits
+  io.frontend_control_x.ready := issueOperand.io.control_x.ready
+  issueOperand.io.control_v.valid := io.frontend_control_v.valid
+  issueOperand.io.control_v.bits := io.frontend_control_v.bits
+  io.frontend_control_v.ready := issueOperand.io.control_v.ready
+  issueOperand.io.write_scalar.valid := io.write_scalar.valid
+  issueOperand.io.write_scalar.bits := io.write_scalar.bits
+  io.write_scalar.ready := issueOperand.io.write_scalar.ready
+  issueOperand.io.write_vec.valid := io.write_vec.valid
+  issueOperand.io.write_vec.bits := io.write_vec.bits
+  io.write_vec.ready := issueOperand.io.write_vec.ready
+  issueOperand.io.sgpr_base := scalarExec.io.sgpr_base
+  issueOperand.io.vgpr_base := scalarExec.io.vgpr_base
+  issueOperand.io.simt_mask := controlFlow.io.simt_mask
+  scalarExec.io.csr_rm_wid(0) := issueOperand.io.fpu.bits.ctrl.wid
+  scalarExec.io.csr_rm_wid(1) := issueOperand.io.sfu.bits.ctrl.wid
+  scalarExec.io.csr_rm_wid(2) := issueOperand.io.tc.bits.ctrl.wid
+  scalarExec.io.csr_simt_wid := issueOperand.io.simt.bits.wid
+  scalarExec.io.issue_salu.valid := issueOperand.io.salu.valid
+  scalarExec.io.issue_salu.bits := issueOperand.io.salu.bits
+  issueOperand.io.salu.ready := scalarExec.io.issue_salu_ready
+  scalarExec.io.issue_csr.valid := issueOperand.io.csr.valid
+  scalarExec.io.issue_csr.bits := issueOperand.io.csr.bits
+  issueOperand.io.csr.ready := scalarExec.io.issue_csr_ready
+  io.warp_lifecycle.valid := issueOperand.io.lifecycle.valid
+  io.warp_lifecycle.bits := issueOperand.io.lifecycle.bits
+  issueOperand.io.lifecycle.ready := io.warp_lifecycle.ready
+  localValu.io.in <> issueOperand.io.valu
+  vectorExec.io.issue_fpu.valid := issueOperand.io.fpu.valid; vectorExec.io.issue_fpu.bits := issueOperand.io.fpu.bits; issueOperand.io.fpu.ready := vectorExec.io.issue_fpu_ready
+  vectorExec.io.issue_sfu.valid := issueOperand.io.sfu.valid; vectorExec.io.issue_sfu.bits := issueOperand.io.sfu.bits; issueOperand.io.sfu.ready := vectorExec.io.issue_sfu_ready
+  vectorExec.io.issue_tc.valid := issueOperand.io.tc.valid; vectorExec.io.issue_tc.bits := issueOperand.io.tc.bits; issueOperand.io.tc.ready := vectorExec.io.issue_tc_ready
+  memoryExec.io.issue_lsu.valid := issueOperand.io.lsu.valid; memoryExec.io.issue_lsu.bits := issueOperand.io.lsu.bits; issueOperand.io.lsu.ready := memoryExec.io.issue_lsu_ready
+  localMul.io.in <> issueOperand.io.mul
+  controlFlow.io.simt_issue <> issueOperand.io.simt
+
+  controlFlow.io.valu_mask <> localValu.io.out2simt_stack
+  controlFlow.io.scalar_branch.valid := scalarExec.io.alu_branch.valid
+  controlFlow.io.scalar_branch.bits := scalarExec.io.alu_branch.bits
+  scalarExec.io.alu_branch.ready := controlFlow.io.scalar_branch.ready
+  controlFlow.io.pc_reconv := scalarExec.io.simt_rpc
+  controlFlow.io.warp_init := io.warp_init
+  io.branch_out.valid := controlFlow.io.branch.valid
+  io.branch_out.bits := controlFlow.io.branch.bits
+  controlFlow.io.branch.ready := io.branch_out.ready
+  io.simt_complete.valid := controlFlow.io.complete.valid
+  io.simt_complete.bits := controlFlow.io.complete.bits
+
+  io.compute_valu_vec.valid := localValu.io.out.valid
+  io.compute_valu_vec.bits := localValu.io.out.bits
+  localValu.io.out.ready := io.compute_valu_vec.ready
+  io.compute_mul_scalar.valid := localMul.io.out_x.valid
+  io.compute_mul_scalar.bits := localMul.io.out_x.bits
+  localMul.io.out_x.ready := io.compute_mul_scalar.ready
+  io.compute_mul_vec.valid := localMul.io.out_v.valid
+  io.compute_mul_vec.bits := localMul.io.out_v.bits
+  localMul.io.out_v.ready := io.compute_mul_vec.ready
+
+  io.scoreboard.op_col_x_in_fire := issueOperand.io.op_col_x_in_fire
+  io.scoreboard.op_col_x_in_wid := issueOperand.io.op_col_x_in_wid
+  io.scoreboard.op_col_x_out_fire := issueOperand.io.op_col_x_out_fire
+  io.scoreboard.op_col_x_out_wid := issueOperand.io.op_col_x_out_wid
+  io.scoreboard.op_col_v_in_fire := issueOperand.io.op_col_v_in_fire
+  io.scoreboard.op_col_v_in_wid := issueOperand.io.op_col_v_in_wid
+  io.scoreboard.op_col_v_out_fire := issueOperand.io.op_col_v_out_fire
+  io.scoreboard.op_col_v_out_wid := issueOperand.io.op_col_v_out_wid
+  io.scoreboard.branch_fire := io.branch_out.fire
+  io.scoreboard.branch_wid := io.branch_out.bits.wid(localDepthWarp - 1, 0)
+  io.scoreboard.simt_complete_fire := io.simt_complete.valid
+  io.scoreboard.simt_complete_wid := io.simt_complete.bits
+  io.scoreboard.endprg_fire := io.warp_lifecycle.fire && io.warp_lifecycle.bits.ctrl.simt_stack_op
+  io.scoreboard.endprg_wid := io.warp_lifecycle.bits.ctrl.wid(localDepthWarp - 1, 0)
+}

--- a/ventus/src/pipeline/WarpLifecycleCtrl.scala
+++ b/ventus/src/pipeline/WarpLifecycleCtrl.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2021-2022 International Innovation Center of Tsinghua University, Shanghai
+ * Ventus is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+package pipeline
+
+import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
+import chisel3.util._
+import top.parameters._
+
+class WarpLifecycleLaunchEvent extends Bundle {
+  val wid = UInt(depth_warp.W)
+  val wf_tag = UInt(TAG_WIDTH.W)
+  val wg_wf_count = UInt(log2Ceil(CTA_SCHE_CONFIG.WG.NUM_WF_MAX + 1).W)
+}
+
+class WarpLifecycleCtrlIO extends Bundle {
+  val launch = Input(Valid(new WarpLifecycleLaunchEvent))
+  val complete = Input(Valid(UInt(depth_warp.W)))
+
+  val branch_jump = Input(Vec(num_subcore, Valid(UInt(depth_warp.W))))
+  val barrier_arrive = Input(Vec(num_subcore, Valid(UInt(depth_warp.W))))
+  val endprg = Input(Vec(num_subcore, Valid(UInt(depth_warp.W))))
+
+  val flush_dcache = DecoupledIO(Bool())
+
+  val wg_tag_lookup = Output(Vec(num_warp, UInt(TAG_WIDTH.W)))
+  val frontend_gen_lookup = Output(Vec(num_warp, UInt(16.W)))
+  val recently_freed = Output(UInt(num_warp.W))
+  val global_barrier_wait = Output(UInt(num_warp.W))
+  val barrier_release_mask = Output(UInt(num_warp.W))
+  val wg_id_lookup = Output(UInt(depth_warp.W))
+}
+
+@instantiable
+class WarpLifecycleCtrl extends Module {
+  @public val io = IO(new WarpLifecycleCtrlIO)
+
+  private val wfIdWidth = log2Ceil(num_warp_in_a_block)
+
+  val wgTagTable = RegInit(VecInit(Seq.fill(num_warp)(0.U(TAG_WIDTH.W))))
+  val frontendGenTable = RegInit(VecInit(Seq.fill(num_warp)(0.U(16.W))))
+  val recentlyFreed = RegInit(0.U(num_warp.W))
+
+  val globalWarpBarCur = RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp_in_a_block.W))))
+  val globalWarpBarExp = RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp_in_a_block.W))))
+  val globalWarpBarBelong = RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp.W))))
+  val globalBarrierWait = RegInit(0.U(num_warp.W))
+  val globalWarpEndCnt = RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp.W))))
+  val globalWarpWgValid = RegInit(VecInit(Seq.fill(num_block)(false.B)))
+
+  io.wg_tag_lookup := wgTagTable
+  io.frontend_gen_lookup := frontendGenTable
+  io.recently_freed := recentlyFreed
+  io.global_barrier_wait := globalBarrierWait
+
+  val needFlushMask = Wire(Vec(num_block, Bool()))
+  for (i <- 0 until num_block) {
+    needFlushMask(i) := (globalWarpEndCnt(i).orR === false.B) && globalWarpWgValid(i)
+  }
+  val flushDCacheValid = needFlushMask.asUInt.orR
+  val flushDCacheEntry = OHToUInt(needFlushMask.asUInt)
+  io.flush_dcache.valid := flushDCacheValid
+  io.flush_dcache.bits := flushDCacheValid
+
+  val barrierWgIdVec = Wire(Vec(num_subcore, UInt((TAG_WIDTH - wfIdWidth).W)))
+  val barrierWfIdVec = Wire(Vec(num_subcore, UInt(wfIdWidth.W)))
+  for (sc <- 0 until num_subcore) {
+    val barrierTag = wgTagTable(io.barrier_arrive(sc).bits)
+    barrierWgIdVec(sc) := barrierTag(TAG_WIDTH - 1, wfIdWidth)
+    barrierWfIdVec(sc) := barrierTag(wfIdWidth - 1, 0)
+  }
+
+  val barrierArriveMask = (0 until num_subcore)
+    .map { sc =>
+      Mux(
+        io.barrier_arrive(sc).valid,
+        UIntToOH(io.barrier_arrive(sc).bits, num_warp),
+        0.U(num_warp.W)
+      )
+    }
+    .reduce(_ | _)
+
+  val barrierReleasePerWg = Wire(Vec(num_block, UInt(num_warp.W)))
+  barrierReleasePerWg.foreach(_ := 0.U)
+  for (wg <- 0 until num_block) {
+    val arrivals = (0 until num_subcore)
+      .map { sc =>
+        Mux(
+          io.barrier_arrive(sc).valid && (barrierWgIdVec(sc) === wg.U),
+          UIntToOH(barrierWfIdVec(sc), num_warp_in_a_block),
+          0.U(num_warp_in_a_block.W)
+        )
+      }
+      .reduce(_ | _)
+    val barrierComplete =
+      arrivals.orR && ((globalWarpBarCur(wg) | arrivals) === globalWarpBarExp(wg))
+
+    when(arrivals.orR) {
+      globalWarpBarCur(wg) := Mux(barrierComplete, 0.U, globalWarpBarCur(wg) | arrivals)
+    }
+    barrierReleasePerWg(wg) := Mux(barrierComplete, globalWarpBarBelong(wg), 0.U)
+  }
+  val barrierReleaseMask = barrierReleasePerWg.reduce(_ | _)
+  io.barrier_release_mask := barrierReleaseMask
+
+  val wgLookupCandidates = (0 until num_subcore).flatMap { sc =>
+    Seq(
+      io.barrier_arrive(sc).valid -> io.barrier_arrive(sc).bits,
+      io.endprg(sc).valid -> io.endprg(sc).bits
+    )
+  }
+  io.wg_id_lookup := MuxCase(0.U(depth_warp.W), wgLookupCandidates)
+
+  when(io.launch.valid) {
+    val newWgId = io.launch.bits.wf_tag(TAG_WIDTH - 1, wfIdWidth)
+    val newWgWfCount = io.launch.bits.wg_wf_count
+    val newWarpMask = UIntToOH(io.launch.bits.wid, num_warp)
+
+    wgTagTable(io.launch.bits.wid) := io.launch.bits.wf_tag
+    frontendGenTable(io.launch.bits.wid) := frontendGenTable(io.launch.bits.wid) + 1.U
+    globalWarpBarBelong(newWgId) := globalWarpBarBelong(newWgId) | newWarpMask
+    when(!globalWarpBarBelong(newWgId).orR) {
+      globalWarpBarCur(newWgId) := 0.U
+      globalWarpBarExp(newWgId) := (1.U << newWgWfCount).asUInt - 1.U
+    }
+    globalWarpEndCnt(newWgId) := globalWarpEndCnt(newWgId) | newWarpMask
+    globalWarpWgValid(newWgId) := true.B
+  }
+
+  when(io.complete.valid) {
+    val endTag = wgTagTable(io.complete.bits)
+    val endWgId = endTag(TAG_WIDTH - 1, wfIdWidth)
+    val endWarpMask = UIntToOH(io.complete.bits, num_warp)
+
+    globalWarpBarBelong(endWgId) := globalWarpBarBelong(endWgId) & (~endWarpMask).asUInt
+    globalWarpEndCnt(endWgId) := globalWarpEndCnt(endWgId) & (~endWarpMask).asUInt
+  }
+
+  val recentAllocMask =
+    Mux(io.launch.valid, UIntToOH(io.launch.bits.wid, num_warp), 0.U(num_warp.W))
+  val recentFreeMask =
+    Mux(io.complete.valid, UIntToOH(io.complete.bits, num_warp), 0.U(num_warp.W))
+  recentlyFreed := (recentlyFreed | recentFreeMask) & (~recentAllocMask).asUInt
+
+  when(flushDCacheValid && io.flush_dcache.ready) {
+    globalWarpWgValid(flushDCacheEntry) := false.B
+  }
+
+  for (sc <- 0 until num_subcore) {
+    when(io.branch_jump(sc).valid) {
+      frontendGenTable(io.branch_jump(sc).bits) :=
+        frontendGenTable(io.branch_jump(sc).bits) + 1.U
+    }
+  }
+
+  globalBarrierWait := (globalBarrierWait | barrierArriveMask) & (~barrierReleaseMask).asUInt
+}

--- a/ventus/src/pipeline/branch_join.scala
+++ b/ventus/src/pipeline/branch_join.scala
@@ -11,6 +11,7 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
 import java.io._
@@ -64,8 +65,9 @@ class branch_join_stack(val depth:Int) extends Module{
   io.newMask := stack_mem(rd_ptr).newMask
 }
 
-class branch_join(val depth_stack: Int) extends Module{
-  val io = IO(new Bundle() {
+@instantiable
+class branch_join(val depth_stack: Int, val nWarps: Int = num_warp) extends Module{
+  @public val io = IO(new Bundle() {
     val branch_ctl = Flipped(Decoupled(new simtExeData()))
     val if_mask = Flipped(Decoupled(new vec_alu_bus()))
     val pc_reconv = Flipped(Decoupled(UInt(xLen.W)))
@@ -93,7 +95,7 @@ class branch_join(val depth_stack: Int) extends Module{
 
   val fetch_ctl_buf = Module(new Queue(new BranchCtrl, 1, flow = true))
 
-  val thread_masks = RegInit(VecInit(Seq.fill(num_warp)(~0.U(num_thread.W))))
+  val thread_masks = RegInit(VecInit(Seq.fill(nWarps)(~0.U(num_thread.W))))
   val if_mask = Wire(UInt(num_thread.W))
   // val if_mask = WireInit(~0.U(num_thread.W))
   val else_mask = WireInit(0.U(num_thread.W))
@@ -105,17 +107,17 @@ class branch_join(val depth_stack: Int) extends Module{
   val elseCnt = Wire(UInt(log2Ceil(num_thread+1).W))
   val takeif = Wire(Bool())
 
-  val push = WireInit(VecInit(Seq.fill(num_warp)(false.B))) //Wire(Vec(num_warp,Bool()))
-  val pop = WireInit(VecInit(Seq.fill(num_warp)(false.B))) //Wire(Vec(num_warp,Bool()))
-  val bjjump = WireInit(VecInit(Seq.fill(num_warp)(false.B)))
-  val bjPC = WireInit(VecInit(Seq.fill(num_warp)(0.U(32.W))))
-  val bjmask = WireInit(VecInit(Seq.fill(num_warp)(0.U(num_thread.W))))
+  val push = WireInit(VecInit(Seq.fill(nWarps)(false.B)))
+  val pop = WireInit(VecInit(Seq.fill(nWarps)(false.B)))
+  val bjjump = WireInit(VecInit(Seq.fill(nWarps)(false.B)))
+  val bjPC = WireInit(VecInit(Seq.fill(nWarps)(0.U(32.W))))
+  val bjmask = WireInit(VecInit(Seq.fill(nWarps)(0.U(num_thread.W))))
   val popjump = Wire(Bool())
   val popPC = Wire(UInt(32.W))
   val popMask = Wire(UInt(num_thread.W))
 
 
-  val bjstack  = VecInit(Seq.fill(num_warp)(Module(new branch_join_stack(depth_stack)).io))
+  val bjstack  = VecInit(Seq.fill(nWarps)(Module(new branch_join_stack(depth_stack)).io))
   var x = 0
   opcode := branch_ctl_buf.bits.opcode
   PC_branch := branch_ctl_buf.bits.PC_branch
@@ -161,7 +163,7 @@ class branch_join(val depth_stack: Int) extends Module{
     pushentry.jumpPC  :=  PC_execute + 4.U
   }
 
-  for(x <- 0 until num_warp){
+  for(x <- 0 until nWarps){
     push(x)  :=  (opcode === 0.U) && (branch_ctl_buf.fire) && (x.asUInt === warp_id ) && divOccur
     pop(x) := (opcode === 1.U) && (branch_ctl_buf.fire) && (x.asUInt === warp_id) //just indicating this is join, maybe not pop, depends on whether TOS rPC match current executing PC
     bjstack(x).push := push(x)
@@ -275,4 +277,3 @@ class branch_join(val depth_stack: Int) extends Module{
     assert(bjstack(io.initMask.bits.warp_id).empty, "SIMTstack should be empty when initMask is valid")
   }
 }
-

--- a/ventus/src/pipeline/execution.scala
+++ b/ventus/src/pipeline/execution.scala
@@ -13,6 +13,7 @@ package pipeline
 import FPUv2.TensorCoreFP32
 import FPUv2.utils.{EmptyFPUCtrl, TestFPUCtrl}
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
 import IDecode._
@@ -23,8 +24,9 @@ class BranchCtrl extends Bundle{
   val new_pc=UInt(32.W)
   val spike_info = if (SPIKE_OUTPUT) Some(new InstWriteBack) else None
 }
+@instantiable
 class ALUexe extends Module{
-  val io = IO(new Bundle() {
+  @public val io = IO(new Bundle() {
     val in = Flipped(DecoupledIO(new sExeData()))
     val out = DecoupledIO(new WriteScalarCtrl())
     val out2br = DecoupledIO(new BranchCtrl())
@@ -112,8 +114,9 @@ class vMULexe extends Module{
 class TCCtrlv2(xLen: Int, depth_warp: Int) extends FPUv2.TCCtrl(xLen, depth_warp){
   val spike_info=if(SPIKE_OUTPUT) Some(new InstWriteBack) else None
 }
+@instantiable
 class vTCexe extends Module{
-  val io = IO(new Bundle {
+  @public val io = IO(new Bundle {
     val in = Flipped(DecoupledIO(new vExeData()))
     val rm = Input(UInt(3.W))
     //val out_x = DecoupledIO(new WriteScalarCtrl())
@@ -161,6 +164,7 @@ class vTCexe extends Module{
 
 }
 
+@instantiable
 class vMULv2(softThread: Int = num_thread, hardThread: Int = num_thread) extends Module {
   assert(softThread % hardThread == 0)
   class vExeData2(num_thread: Int = softThread) extends vExeData {
@@ -180,7 +184,7 @@ class vMULv2(softThread: Int = num_thread, hardThread: Int = num_thread) extends
 //    })
 //  }
 
-  val io = IO(new Bundle{
+  @public val io = IO(new Bundle{
     val in = Flipped(DecoupledIO(new vExeData2))
     val out_x = DecoupledIO(new WriteScalarCtrl)
     val out_v = DecoupledIO(new WriteVecCtrl2)
@@ -473,6 +477,7 @@ class vALUexe extends Module{
   io.out2simt_stack<>result2simt.io.deq
 }
 
+@instantiable
 class vALUv2(softThread: Int = num_thread, hardThread: Int = num_thread) extends Module {
   assert(softThread % hardThread == 0)
   //assert(softThread > 2 && hardThread > 1)
@@ -493,7 +498,7 @@ class vALUv2(softThread: Int = num_thread, hardThread: Int = num_thread) extends
     override val if_mask = UInt(num_thread.W)
   }
 
-  val io = IO(new Bundle {
+  @public val io = IO(new Bundle {
     val in = Flipped(DecoupledIO(new vExeData2()))
     val out = DecoupledIO(new WriteVecCtrl2())
     val out2simt_stack = DecoupledIO(new vec_alu_bus2())
@@ -743,9 +748,10 @@ class ctrl_fpu extends Bundle{
 val ctrl=new CtrlSigs
 val mask=Vec(num_thread,Bool())
 }
+@instantiable
 class FPUexe(softThread: Int = num_thread, hardThread: Int = num_thread) extends Module {
     assert(softThread % hardThread == 0)
-  val io = IO(new Bundle {
+  @public val io = IO(new Bundle {
     val in = Flipped(DecoupledIO(new vExeData()))
     val rm = Input(UInt(3.W))
     val out_x = DecoupledIO(new WriteScalarCtrl())
@@ -804,8 +810,9 @@ class FPUexe(softThread: Int = num_thread, hardThread: Int = num_thread) extends
   fpu.io.out.ready := Mux(fpu.io.out.bits.ctrl.wvd, io.out_v.ready, io.out_x.ready)
 }
 
+@instantiable
 class SFUexe extends Module{
-  val io = IO(new Bundle {
+  @public val io = IO(new Bundle {
     val in = Flipped(DecoupledIO(new vExeData()))
     val rm = Input(UInt(3.W))
     val out_x = DecoupledIO(new WriteScalarCtrl())
@@ -943,4 +950,3 @@ class SFUexe extends Module{
   io.out_v<>result_v.io.deq
   io.out_x<>result_x.io.deq
 }
-

--- a/ventus/src/pipeline/ibuffer.scala
+++ b/ventus/src/pipeline/ibuffer.scala
@@ -39,9 +39,10 @@ class instbuffer extends Module{
   })
   //val arbiter=Module(new arbiter_m2o(3))
 }
-class ibuffer2issue extends Module{
+class ibuffer2issue(val nWarps: Int = num_warp) extends Module{
+  require(nWarps >= 1)
   val io = IO(new Bundle{
-    val in=Flipped(Vec(num_warp,Decoupled(new CtrlSigs)))
+    val in=Flipped(Vec(nWarps,Decoupled(new CtrlSigs)))
     //val out=Decoupled(new CtrlSigs)
     val out_x = Decoupled(new CtrlSigs)
     val out_v = Decoupled(new CtrlSigs)
@@ -61,8 +62,8 @@ class ibuffer2issue extends Module{
     io.cnt.foreach(_ := cnt)
   }
   //
-  val rrarbit_x=Module(new RRArbiter(new CtrlSigs(),num_warp))
-  val rrarbit_v=Module(new RRArbiter(new CtrlSigs(),num_warp))
+  val rrarbit_x=Module(new RRArbiter(new CtrlSigs(),nWarps))
+  val rrarbit_v=Module(new RRArbiter(new CtrlSigs(),nWarps))
   def inst_is_vec(in: CtrlSigs): Bool = {
     val out = Wire(new Bool)
     // sALU | CSR | warpscheduler
@@ -78,7 +79,7 @@ class ibuffer2issue extends Module{
     }
     out
   }
-  (0 until num_warp).foreach{ i =>
+  (0 until nWarps).foreach{ i =>
     rrarbit_x.io.in(i).valid := io.in(i).valid && !inst_is_vec(io.in(i).bits)
     rrarbit_x.io.in(i).bits := io.in(i).bits
     rrarbit_v.io.in(i).valid := io.in(i).valid && inst_is_vec(io.in(i).bits)
@@ -102,36 +103,44 @@ class ibuffer2issue extends Module{
 
 // "num_fetch -> 1" slow down
 //
-class InstrBufferV2 extends Module{
+class InstrBufferV2(val nWarps: Int = num_warp, val subcoreId: Int = -1) extends Module{
+  require(nWarps >= 1)
+  require(subcoreId < num_subcore)
   val io = IO(new Bundle{
     val in = Flipped(DecoupledIO(new Bundle{
       val control = Vec(num_fetch, new CtrlSigs)
       val control_mask = Vec(num_fetch, Bool())
     }))
-    val flush_wid = Flipped(ValidIO(UInt(depth_warp.W)))
-    val ibuffer_ready = Output(Vec(num_warp, Bool()))
-    val out = Vec(num_warp, DecoupledIO(Output(new CtrlSigs)))
+    val flush_wid = Input(UInt(nWarps.W))
+    val ibuffer_ready = Output(Vec(nWarps, Bool()))
+    val out = Vec(nWarps, DecoupledIO(Output(new CtrlSigs)))
   })
-  val buffers = VecInit(Seq.fill(num_warp)(Module(new Queue(Vec(num_fetch, new CtrlSigs), size_ibuffer, hasFlush = true)).io))
-  val buffers_mask = VecInit(Seq.fill(num_warp)(Module(new Queue(Vec(num_fetch, Bool()), size_ibuffer, hasFlush = true)).io))
-  (0 until num_warp).foreach{ i =>
-    buffers(i).enq.valid := io.in.bits.control(0).wid === i.U && io.in.valid
+  private val localWidWidth = if (nWarps <= 1) 1 else log2Ceil(nWarps)
+  val inputWid = if (nWarps <= 1) 0.U(1.W) else io.in.bits.control(0).wid(localWidWidth - 1, 0)
+  val buffers = VecInit(Seq.fill(nWarps)(Module(new Queue(Vec(num_fetch, new CtrlSigs), size_ibuffer, hasFlush = true)).io))
+  val buffers_mask = VecInit(Seq.fill(nWarps)(Module(new Queue(Vec(num_fetch, Bool()), size_ibuffer, hasFlush = true)).io))
+  (0 until nWarps).foreach{ i =>
+    buffers(i).enq.valid := inputWid === i.U && io.in.valid
     buffers(i).enq.bits := io.in.bits.control
-    buffers(i).flush.foreach{ _ := io.flush_wid.valid && io.flush_wid.bits === i.U }
-    buffers_mask(i).enq.valid := io.in.bits.control(0).wid === i.U && io.in.valid
+    buffers(i).flush.foreach{ _ := io.flush_wid(i) }
+    buffers_mask(i).enq.valid := inputWid === i.U && io.in.valid
     buffers_mask(i).enq.bits := io.in.bits.control_mask
-    buffers_mask(i).flush.foreach{ _ := io.flush_wid.valid && io.flush_wid.bits === i.U }
-    io.in.ready := buffers(io.in.bits.control(0).wid).enq.ready
+    buffers_mask(i).flush.foreach{ _ := io.flush_wid(i) }
+    io.in.ready := buffers(inputWid).enq.ready
     io.ibuffer_ready(i) := buffers(i).enq.ready
   }
 
-  io.in.ready := buffers(io.in.bits.control(0).wid).enq.ready
+  io.in.ready := buffers(inputWid).enq.ready
   when(io.in.fire){
-    buffers(io.in.bits.control(0).wid).enq.bits := io.in.bits.control
-    buffers_mask(io.in.bits.control(0).wid).enq.bits := io.in.bits.control_mask
-    when(io.flush_wid.valid){
-      buffers(io.flush_wid.bits).enq.bits := 0.U.asTypeOf(Vec(num_fetch, new CtrlSigs))
-      buffers_mask(io.flush_wid.bits).enq.bits := 0.U.asTypeOf(Vec(num_fetch, Bool()))
+    buffers(inputWid).enq.bits := io.in.bits.control
+    buffers_mask(inputWid).enq.bits := io.in.bits.control_mask
+    when(io.flush_wid.orR && !io.flush_wid(inputWid)){
+      (0 until nWarps).foreach { i =>
+        when(io.flush_wid(i) && inputWid =/= i.U) {
+          buffers(i).enq.bits := 0.U.asTypeOf(Vec(num_fetch, new CtrlSigs))
+          buffers_mask(i).enq.bits := 0.U.asTypeOf(Vec(num_fetch, Bool()))
+        }
+      }
     }
   }
   class SlowDown extends Module{
@@ -175,9 +184,9 @@ class InstrBufferV2 extends Module{
       // the first instruction's id is 1 instead of 0
     }
   }
-  val slowDownArray = Seq.fill(num_warp)(Module(new SlowDown))
-  (0 until num_warp).foreach{ i =>
-    slowDownArray(i).io.flush := io.flush_wid.bits === i.U && io.flush_wid.valid
+  val slowDownArray = Seq.fill(nWarps)(Module(new SlowDown))
+  (0 until nWarps).foreach{ i =>
+    slowDownArray(i).io.flush := io.flush_wid(i)
     slowDownArray(i).io.in.bits.control := buffers(i).deq.bits
     slowDownArray(i).io.in.bits.control_mask := buffers_mask(i).deq.bits
     slowDownArray(i).io.in.valid := buffers(i).deq.valid
@@ -189,16 +198,41 @@ class InstrBufferV2 extends Module{
   
   if (GVM_ENABLED) {
     val gvm_dispatch = Module(new GvmDutInsnDispatch)
-    // 共有 num_warp 个 dispatch 通道
+    // One dispatch observation channel per warp in this buffer bank.
+    def localChannel(globalWid: Int): Option[Int] = {
+      if (subcoreId >= 0) {
+        val owner = globalWid & (num_subcore - 1)
+        val localWid = globalWid >> subcore_sel_bits
+        if (owner == subcoreId && localWid < nWarps) Some(localWid) else None
+      } else if (globalWid < nWarps) {
+        Some(globalWid)
+      } else {
+        None
+      }
+    }
     gvm_dispatch.io.clock := clock
     gvm_dispatch.io.reset := reset.asBool
-    gvm_dispatch.io.dispatch_fire := VecInit(io.out.map(_.fire.asUInt)).asUInt
-    gvm_dispatch.io.sm_id := VecInit(io.out.map(_.bits.spike_info.get.sm_id.pad(32))).asUInt
-    gvm_dispatch.io.hardware_warp_id := VecInit.tabulate(num_warp)(i => i.U(32.W)).asUInt
-    gvm_dispatch.io.pc := VecInit(io.out.map(_.bits.spike_info.get.pc.asUInt)).asUInt
-    gvm_dispatch.io.instr := VecInit(io.out.map(_.bits.spike_info.get.inst.asUInt)).asUInt
-    gvm_dispatch.io.dispatch_id := VecInit(io.out.map(_.bits.spike_info.get.dispatch_id.get.asUInt)).asUInt
-    gvm_dispatch.io.is_extended := VecInit(io.out.map(_.bits.spike_info.get.is_extended.get)).asUInt
+    gvm_dispatch.io.dispatch_fire := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).fire).getOrElse(false.B)
+    }.asUInt
+    gvm_dispatch.io.sm_id := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).bits.spike_info.get.sm_id.pad(32)).getOrElse(0.U(32.W))
+    }.asUInt
+    gvm_dispatch.io.hardware_warp_id := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(_ => globalWid.U(32.W)).getOrElse(0.U(32.W))
+    }.asUInt
+    gvm_dispatch.io.pc := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).bits.spike_info.get.pc.asUInt).getOrElse(0.U(32.W))
+    }.asUInt
+    gvm_dispatch.io.instr := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).bits.spike_info.get.inst.asUInt).getOrElse(0.U(32.W))
+    }.asUInt
+    gvm_dispatch.io.dispatch_id := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).bits.spike_info.get.dispatch_id.get.asUInt).getOrElse(0.U(32.W))
+    }.asUInt
+    gvm_dispatch.io.is_extended := VecInit.tabulate(num_warp) { globalWid =>
+      localChannel(globalWid).map(io.out(_).bits.spike_info.get.is_extended.get).getOrElse(false.B)
+    }.asUInt
   }
   
 }

--- a/ventus/src/pipeline/issue.scala
+++ b/ventus/src/pipeline/issue.scala
@@ -11,6 +11,7 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
 
@@ -37,8 +38,9 @@ class csrExeData extends Bundle{
   val in1=UInt(xLen.W)
 }
 
+@instantiable
 class Issue extends Module{
-  val io = IO(new Bundle{
+  @public val io = IO(new Bundle{
     val in=Flipped(DecoupledIO(new vExeData))
     val out_sALU=DecoupledIO(new sExeData)
     val out_vALU=DecoupledIO(new vExeData)

--- a/ventus/src/pipeline/operandCollector.scala
+++ b/ventus/src/pipeline/operandCollector.scala
@@ -1,6 +1,7 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters._
 import IDecode._
@@ -46,15 +47,24 @@ class issueIO extends Bundle{
 /**
  *One of the number of num_warp collector Units, instantiating this class in operand collector for num_warps.
  */
-class collectorUnit extends Module{
+class collectorUnit(val nWarps: Int = num_warp) extends Module{
+  private val localWarpIdxWidth = if (nWarps == 1) 1 else log2Ceil(nWarps)
+  private def localWarpIdx(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W) else wid(localWarpIdxWidth - 1, 0)
+  }
+  private def localBankWid(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W)
+    else wid(scala.math.min(localWarpIdxWidth, log2Ceil(num_bank)) - 1, 0)
+  }
+
   val io = IO(new Bundle{
     val control = Flipped(Decoupled(new CtrlSigs))
     val bankIn = Vec(4, Flipped(Decoupled(new crossbar2CU)))
     //operand to be issued, alternatively vector and scalar
     val issue = Decoupled(new issueIO)
     val outArbiterIO = Vec(4, Decoupled(new CU2Arbiter))
-    val sgpr_base = Input(Vec(num_warp, UInt((SGPR_ID_WIDTH + 1).W)))
-    val vgpr_base = Input(Vec(num_warp, UInt((VGPR_ID_WIDTH + 1).W)))
+    val sgpr_base = Input(Vec(nWarps, UInt((SGPR_ID_WIDTH + 1).W)))
+    val vgpr_base = Input(Vec(nWarps, UInt((VGPR_ID_WIDTH + 1).W)))
 
   })
   val controlReg = Reg(new CtrlSigs)
@@ -84,44 +94,31 @@ class collectorUnit extends Module{
 
   val s_idle :: s_add :: s_out :: Nil = Enum(3)
   val state = RegInit(s_idle)
-  // Lookup table for address transformation
-  // generate tuple: warp_id -> bank_id (bank id of r0 in this warp. this is interleave)
-  val bankIdLookup = (0 until num_warp + 256).map { x =>
-    (x -> x % num_bank)
-  }.map { x => (x._1.U -> x._2.U) }
-  // reg addr in one bank
-  val addrLookupScalar = (0 until num_warp).map { x =>
-    (x -> (io.sgpr_base(x) >> log2Ceil(num_bank)).asUInt)
-  }.map { x => (x._1.U -> x._2) }
-  val addrLookupVector = (0 until num_warp).map { x =>
-    (x -> (io.vgpr_base(x) >> log2Ceil(num_bank)).asUInt)
-  }.map { x => (x._1.U -> x._2) }
-
   //reading the register bank for those operand which type is not an immediate
   for (i <- 0 until 4) {
 
     io.outArbiterIO(i).bits.bankID := Mux(io.control.fire && (state === s_idle),
-      io.control.bits.wid(widSliceHigh, 0) + regIdxWire(i)(log2Ceil(num_bank)-1, 0),
-      controlReg.wid(widSliceHigh, 0) + regIdx(i)(log2Ceil(num_bank)-1, 0))
+      localBankWid(io.control.bits.wid) + regIdxWire(i)(log2Ceil(num_bank)-1, 0),
+      localBankWid(controlReg.wid) + regIdx(i)(log2Ceil(num_bank)-1, 0))
     io.outArbiterIO(i).bits.rsType := Mux(io.control.fire && (state === s_idle), rsTypeWire(i), rsType(i))
 
     when(Mux(io.control.fire && (state === s_idle), rsTypeWire(i), rsType(i)) === 1.U) {
       when(io.control.fire && (state === s_idle)) {
-        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(io.control.bits.wid) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(localWarpIdx(io.control.bits.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
       }.otherwise {
-        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(controlReg.wid) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(localWarpIdx(controlReg.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
       }
     }.elsewhen(Mux(io.control.fire && (state === s_idle), rsTypeWire(i), rsType(i)) === 2.U) {
       when(io.control.fire && (state === s_idle)) {
-        io.outArbiterIO(i).bits.rsAddr := (io.vgpr_base(io.control.bits.wid) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.vgpr_base(localWarpIdx(io.control.bits.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
       }.otherwise {
-        io.outArbiterIO(i).bits.rsAddr := (io.vgpr_base(controlReg.wid) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.vgpr_base(localWarpIdx(controlReg.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
       }
     }.otherwise {
       when(io.control.fire && (state === s_idle)) {
-        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(io.control.bits.wid) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(localWarpIdx(io.control.bits.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdxWire(i) >> log2Ceil(num_bank).U)
       }.otherwise {
-        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(controlReg.wid) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
+        io.outArbiterIO(i).bits.rsAddr := (io.sgpr_base(localWarpIdx(controlReg.wid)) >> log2Ceil(num_bank).U).asUInt + (regIdx(i) >> log2Ceil(num_bank).U)
       }
     }
   }
@@ -326,28 +323,28 @@ class collectorUnit extends Module{
  * Arbitrating which reading (TO DO: writing) request should
  * be send to register files
  */
-class operandArbiter extends Module{
+class operandArbiter(val nWarps: Int = num_warp) extends Module{
   val io = IO(new Bundle{
-    val readArbiterIO = Vec(num_collectorUnit, Vec(4, Flipped(Decoupled(new CU2Arbiter))))
+    val readArbiterIO = Vec(nWarps, Vec(4, Flipped(Decoupled(new CU2Arbiter))))
     val readArbiterOutScalar = Vec(num_bank, Decoupled(new CU2Arbiter)) //address of registers to be read that in Scalar bank
     val readArbiterOutVector = Vec(num_bank, Decoupled(new CU2Arbiter)) //address of registers to be read that in Vector bank
-    val readchosenScalar = Output(Vec(num_bank, UInt((log2Ceil(4*num_collectorUnit)).W)))// which operand read request is chosen
-    val readchosenVector = Output(Vec(num_bank, UInt((log2Ceil(4*num_collectorUnit)).W)))// which operand read request is chosen
+    val readchosenScalar = Output(Vec(num_bank, UInt((log2Ceil(4*nWarps)).W)))// which operand read request is chosen
+    val readchosenVector = Output(Vec(num_bank, UInt((log2Ceil(4*nWarps)).W)))// which operand read request is chosen
     //    val writeArbiterIO = Decoupled(/*write arbiter, TBD   */)
 
   })
   val bankArbiterScalar = for(i<-0 until num_bank)yield{
-    val x = Module(new RRArbiter(new CU2Arbiter, 4*num_collectorUnit))
+    val x = Module(new RRArbiter(new CU2Arbiter, 4*nWarps))
     x
   }
   val bankArbiterVector = for (i <- 0 until num_bank) yield {
-    val x = Module(new RRArbiter(new CU2Arbiter, 4 * num_collectorUnit))
+    val x = Module(new RRArbiter(new CU2Arbiter, 4 * nWarps))
     x
   }
 
   for (i <- 0 until num_bank) {
     //    mapping input signals from collector units to inputs of Arbiters
-    for (j <- 0 until num_collectorUnit){
+    for (j <- 0 until nWarps){
       for (k <- 0 until 4){
         bankArbiterScalar(i).io.in(j*4+k) <> io.readArbiterIO(j)(k)
         bankArbiterVector(i).io.in(j*4+k) <> io.readArbiterIO(j)(k)
@@ -357,7 +354,7 @@ class operandArbiter extends Module{
 
   //elaborate valid port of readArbiters
   for (i <- 0 until num_bank){
-    for(j <- 0 until num_collectorUnit)
+    for(j <- 0 until nWarps)
       for(k <- 0 until 4){
         bankArbiterScalar(i).io.in(j*4+k).valid := io.readArbiterIO(j)(k).valid &&
           (io.readArbiterIO(j)(k).bits.bankID === i.U) && (io.readArbiterIO(j)(k).bits.rsType === 1.U)
@@ -377,10 +374,11 @@ class operandArbiter extends Module{
 
 }
 
-class crossBar  extends Module{
+class crossBar(val nWarps: Int = num_warp)  extends Module{
+  private val warpSelWidth = if (nWarps == 1) 1 else log2Ceil(nWarps)
   val io = IO(new Bundle {
-    val chosenScalar = Input(Vec(num_bank, UInt(log2Ceil(4 * num_collectorUnit).W)))
-    val chosenVector = Input(Vec(num_bank, UInt(log2Ceil(4 * num_collectorUnit).W)))
+    val chosenScalar = Input(Vec(num_bank, UInt(log2Ceil(4 * nWarps).W)))
+    val chosenVector = Input(Vec(num_bank, UInt(log2Ceil(4 * nWarps).W)))
     val validArbiterScalar = Input(Vec(num_bank, Bool()))
     val validArbiterVector = Input(Vec(num_bank, Bool()))
     val dataInScalar = Input(new Bundle{
@@ -390,10 +388,10 @@ class crossBar  extends Module{
       val rs = Vec(num_bank, Vec(num_thread, UInt(xLen.W)))
       val v0 = Vec(num_bank, Vec(num_thread, UInt((xLen).W)))
     })
-    val out = Vec(num_collectorUnit, Vec(4, Decoupled(new crossbar2CU)))
+    val out = Vec(nWarps, Vec(4, Decoupled(new crossbar2CU)))
   })
-  val CUIdScalar = Wire(Vec(num_bank, UInt(log2Ceil(num_collectorUnit).W)))
-  val CUIdVector = Wire(Vec(num_bank, UInt(log2Ceil(num_collectorUnit).W)))
+  val CUIdScalar = Wire(Vec(num_bank, UInt(warpSelWidth.W)))
+  val CUIdVector = Wire(Vec(num_bank, UInt(warpSelWidth.W)))
   val regOrderScalar = Wire(Vec(num_bank, UInt(2.W)))
   val regOrderVector = Wire(Vec(num_bank, UInt(2.W)))
 
@@ -411,7 +409,7 @@ class crossBar  extends Module{
   io.out.foreach(_.foreach(_.valid := (false.B)))
   io.out.foreach(_.foreach(_.bits.regOrder := 0.U))
   for( i <- 0 until num_bank){
-    for(j <- 0 until num_collectorUnit){
+    for(j <- 0 until nWarps){
       for(k <- 0 until 4){
         when((CUIdScalar(i)===j.U) && io.validArbiterScalar(i) &&(regOrderScalar(i)===k.U)){
           io.out(j)(k).bits.data := VecInit.fill(num_thread)(io.dataInScalar.rs(i))
@@ -437,15 +435,15 @@ class crossBar  extends Module{
 /**
  * Allocating the collector unit to new input instruction
  */
-class instDemux extends Module{
+class instDemux(val nWarps: Int = num_warp) extends Module{
   val io = IO(new Bundle{
     val in = Vec(2, Flipped(Decoupled(new CtrlSigs)))
-    val sgpr_baseIn = Input(Vec(num_warp, UInt((SGPR_ID_WIDTH + 1).W)))
-    val vgpr_baseIn = Input(Vec(num_warp, UInt((VGPR_ID_WIDTH + 1).W)))
-    val out = Vec(num_collectorUnit, Decoupled(new CtrlSigs))
-    val sgpr_baseOut = Output(Vec(num_warp, UInt((SGPR_ID_WIDTH + 1).W)))
-    val vgpr_baseOut = Output(Vec(num_warp, UInt((VGPR_ID_WIDTH + 1).W)))
-    val widCmp = Input(Vec(num_collectorUnit, Bool()))
+    val sgpr_baseIn = Input(Vec(nWarps, UInt((SGPR_ID_WIDTH + 1).W)))
+    val vgpr_baseIn = Input(Vec(nWarps, UInt((VGPR_ID_WIDTH + 1).W)))
+    val out = Vec(nWarps, Decoupled(new CtrlSigs))
+    val sgpr_baseOut = Output(Vec(nWarps, UInt((SGPR_ID_WIDTH + 1).W)))
+    val vgpr_baseOut = Output(Vec(nWarps, UInt((VGPR_ID_WIDTH + 1).W)))
+    val widCmp = Input(Vec(nWarps, Bool()))
   })
 
   // Each data on out port is identical
@@ -456,13 +454,13 @@ class instDemux extends Module{
   val priorityXorV = RegInit(true.B)
   priorityXorV := ~priorityXorV
   val outReady1 = VecInit(io.out.map(_.ready)).asUInt
-  val outX_sel = Wire(UInt(num_collectorUnit.W))
-  val outV_sel = Wire(UInt(num_collectorUnit.W))
-  val outV_sel_oh = Wire(UInt(num_collectorUnit.W))
-  val outReady2 = Wire(UInt(num_collectorUnit.W))
+  val outX_sel = Wire(UInt(nWarps.W))
+  val outV_sel = Wire(UInt(nWarps.W))
+  val outV_sel_oh = Wire(UInt(nWarps.W))
+  val outReady2 = Wire(UInt(nWarps.W))
 
-  if (num_warp == 1) {
-    val outX_sel_oh = Wire(UInt(num_collectorUnit.W))
+  if (nWarps == 1) {
+    val outX_sel_oh = Wire(UInt(nWarps.W))
     // Alternate priority between V and X to ensure instructions are not blocked when num_warp = 1
     when(priorityXorV) {
       // V has priority
@@ -515,23 +513,33 @@ class instDemux extends Module{
   io.vgpr_baseOut := io.vgpr_baseIn
 
 }
-class operandCollector extends Module{
-  val io=IO(new Bundle {
+@instantiable
+class operandCollector(val nWarps: Int = num_warp) extends Module{
+  private val localWarpIdxWidth = if (nWarps == 1) 1 else log2Ceil(nWarps)
+  private def localWarpIdx(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W) else wid(localWarpIdxWidth - 1, 0)
+  }
+  private def localBankWid(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W)
+    else wid(scala.math.min(localWarpIdxWidth, log2Ceil(num_bank)) - 1, 0)
+  }
+
+  @public val io=IO(new Bundle {
     val controlX=Flipped(Decoupled(new CtrlSigs()))
     val controlV=Flipped(Decoupled(new CtrlSigs()))
     val out=Vec(2, Decoupled(new issueIO))
     val writeScalarCtrl=Flipped(DecoupledIO(new WriteScalarCtrl)) //should be used as decoupledIO
     val writeVecCtrl=Flipped(DecoupledIO(new WriteVecCtrl))
-    val sgpr_base = Input(Vec(num_warp,UInt((SGPR_ID_WIDTH+1).W)))
-    val vgpr_base = Input(Vec(num_warp,UInt((VGPR_ID_WIDTH+1).W)))
+    val sgpr_base = Input(Vec(nWarps,UInt((SGPR_ID_WIDTH+1).W)))
+    val vgpr_base = Input(Vec(nWarps,UInt((VGPR_ID_WIDTH+1).W)))
     val gvmWarpHwId = if (GVM_ENABLED) Some(Input(UInt(depth_warp.W))) else None
     val gvmWarpSgprBase = if (GVM_ENABLED) Some(Input(UInt((SGPR_ID_WIDTH + 1).W))) else None
     val gvmWarpVgprBase = if (GVM_ENABLED) Some(Input(UInt((VGPR_ID_WIDTH + 1).W))) else None
     val gvmWarpXRegs = if (GVM_ENABLED) Some(Output(Vec(NUMBER_SGPR_SLOTS / num_warp, UInt(xLen.W)))) else None
     val gvmWarpVRegs = if (GVM_ENABLED) Some(Output(Vec(NUMBER_VGPR_SLOTS / num_warp, Vec(num_thread, UInt(xLen.W))))) else None
   })
-  val collectorUnits = VecInit(Seq.fill(num_collectorUnit)(Module(new collectorUnit).io))
-  val Arbiter = Module(new operandArbiter)
+  val collectorUnits = VecInit(Seq.fill(nWarps)(Module(new collectorUnit(nWarps)).io))
+  val Arbiter = Module(new operandArbiter(nWarps))
   val vectorBank = VecInit(Seq.fill(num_bank)(Module(new FloatRegFileBank).io))
   val scalarBank = VecInit(Seq.fill(num_bank)(Module(new RegFileBank).io))
   if (GVM_ENABLED) {
@@ -548,10 +556,10 @@ class operandCollector extends Module{
       io.gvmWarpVRegs.get(regIdx) := vectorBank(bankId).all_regs.get(bankAddr)
     }
   }
-  val crossBar = Module(new crossBar)
-  val Demux = Module(new instDemux)
+  val crossBar = Module(new crossBar(nWarps))
+  val Demux = Module(new instDemux(nWarps))
   // connecting Arbiters and banks
-  (0 until num_collectorUnit).foreach(i => {collectorUnits(i).outArbiterIO <> Arbiter.io.readArbiterIO(i)})
+  (0 until nWarps).foreach(i => {collectorUnits(i).outArbiterIO <> Arbiter.io.readArbiterIO(i)})
   (0 until num_bank).foreach(i=>{
     vectorBank(i).rsidx := Arbiter.io.readArbiterOutVector(i).bits.rsAddr
     scalarBank(i).rsidx := Arbiter.io.readArbiterOutScalar(i).bits.rsAddr
@@ -569,13 +577,12 @@ class operandCollector extends Module{
     crossBar.io.dataInVector.v0(i) := vectorBank(i).v0
   }
   // connecting crossbar and collector units
-  (0 until num_collectorUnit).foreach(i => {collectorUnits(i).bankIn <> crossBar.io.out(i)})
+  (0 until nWarps).foreach(i => {collectorUnits(i).bankIn <> crossBar.io.out(i)})
 
   //CU allocation
-  val widReg = RegInit(VecInit.fill(num_collectorUnit)(0.U(log2Ceil(num_collectorUnit).W)))
-  val widCmp = Wire(Vec(num_collectorUnit, Bool()))
+  val widCmp = Wire(Vec(nWarps, Bool()))
   //Since arbitration has finished in scoreboard, each instruction in this stage should fetch operand unless there is no more collect unit.
-  (0 until num_collectorUnit).foreach( i => {
+  (0 until nWarps).foreach( i => {
     //    widCmp(i) := io.control.bits.wid===collectorUnits(i).wid
     widCmp(i) := 0.U
   })
@@ -584,7 +591,7 @@ class operandCollector extends Module{
   Demux.io.in(1) <> io.controlX
   Demux.io.sgpr_baseIn := io.sgpr_base
   Demux.io.vgpr_baseIn := io.vgpr_base
-  for(i <- 0 until num_collectorUnit){
+  for(i <- 0 until nWarps){
     collectorUnits(i).control <> Demux.io.out(i)
     collectorUnits(i).sgpr_base := Demux.io.sgpr_baseOut
     collectorUnits(i).vgpr_base := Demux.io.vgpr_baseOut
@@ -593,33 +600,15 @@ class operandCollector extends Module{
   // writeback control
   // bankID = (wid + regIdx) % num_bank
   // rsAddr =  [gpr_base(i) + regIdx)] / num_bank
-  val bankIdLookup = (0 until num_warp + 256).map { x =>
-    (x -> x % num_bank)
-  }.map { x => (x._1.U -> x._2.U) }
-  val addrLookupScalar = (0 until num_warp).map { x =>
-    (x -> (io.sgpr_base(x) >> log2Ceil(num_bank)).asUInt)
-  }.map { x => (x._1.U -> x._2) }
-  val addrLookupVector = (0 until num_warp).map { x =>
-    (x -> (io.vgpr_base(x) >> log2Ceil(num_bank)).asUInt)
-  }.map { x => (x._1.U -> x._2) }
-
   val wbVecBankId = Wire(UInt(2.W))
   val wbScaBankId = Wire(UInt(2.W))
   val wbVecBankAddr = Wire(UInt(depth_regBank.W))
   val wbScaBankAddr = Wire(UInt(depth_regBank.W))
 
-  val sgprW = Wire(UInt(depth_regBank.W))
-  sgprW := io.sgpr_base(io.writeScalarCtrl.bits.warp_id) >> log2Ceil(num_bank).U
-  val regW = Wire(UInt(7.W))
-  regW := io.writeScalarCtrl.bits.reg_idxw >> log2Ceil(num_bank).U
-
-  wbVecBankId := io.writeVecCtrl.bits.reg_idxw(log2Ceil(num_bank)-1,0)+io.writeVecCtrl.bits.warp_id(widSliceHigh,0)
-  wbVecBankAddr := (io.vgpr_base(io.writeVecCtrl.bits.warp_id) >> log2Ceil(num_bank).U).asUInt + (io.writeVecCtrl.bits.reg_idxw >> log2Ceil(num_bank).U)
-  wbScaBankId := io.writeScalarCtrl.bits.reg_idxw(log2Ceil(num_bank)-1,0)+io.writeScalarCtrl.bits.warp_id(widSliceHigh,0)
-  wbScaBankAddr := (io.sgpr_base(io.writeScalarCtrl.bits.warp_id) >> log2Ceil(num_bank).U).asUInt + (io.writeScalarCtrl.bits.reg_idxw >> log2Ceil(num_bank).U)
-  val wbScaBankAddrtest = Wire(UInt(depth_regBank.W))
-  wbScaBankAddrtest := sgprW + regW
-
+  wbVecBankId := io.writeVecCtrl.bits.reg_idxw(log2Ceil(num_bank)-1,0)+localBankWid(io.writeVecCtrl.bits.warp_id)
+  wbVecBankAddr := (io.vgpr_base(localWarpIdx(io.writeVecCtrl.bits.warp_id)) >> log2Ceil(num_bank).U).asUInt + (io.writeVecCtrl.bits.reg_idxw >> log2Ceil(num_bank).U)
+  wbScaBankId := io.writeScalarCtrl.bits.reg_idxw(log2Ceil(num_bank)-1,0)+localBankWid(io.writeScalarCtrl.bits.warp_id)
+  wbScaBankAddr := (io.sgpr_base(localWarpIdx(io.writeScalarCtrl.bits.warp_id)) >> log2Ceil(num_bank).U).asUInt + (io.writeScalarCtrl.bits.reg_idxw >> log2Ceil(num_bank).U)
   vectorBank.foreach(x=>{
     x.rdidx := wbVecBankAddr
     x.rd := io.writeVecCtrl.bits.wb_wvd_rd
@@ -676,11 +665,10 @@ class operandCollector extends Module{
     io.out_v <> arb_v.io.out
   }
 
-  val issueUnit = Module(new DualIssueIO(num_collectorUnit))
-  (0 until num_collectorUnit).foreach{ i =>
+  val issueUnit = Module(new DualIssueIO(nWarps))
+  (0 until nWarps).foreach{ i =>
     issueUnit.io.in(i) <> collectorUnits(i).issue
   }
   io.out(0) <> issueUnit.io.out_v
   io.out(1) <> issueUnit.io.out_x
 }
-

--- a/ventus/src/pipeline/pipe.scala
+++ b/ventus/src/pipeline/pipe.scala
@@ -12,21 +12,30 @@ package pipeline
 
 import L1Cache.ICache._
 import chisel3._
+import chisel3.experimental.hierarchy.{Definition, Instance}
 import chisel3.util._
 import top.parameters._
 import gvm._
 
 class ICachePipeReq_np extends Bundle {
+  private val sourceWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
   val addr = UInt(32.W)
   val mask = UInt(num_fetch.W)
   val warpid = UInt(depth_warp.W)
+  val source = UInt(sourceWidth.W)
+  val wf_tag = UInt(TAG_WIDTH.W)
+  val frontend_gen = UInt(frontend_gen_width.W)
   val asid = if(MMU_ENABLED) Some(UInt(KNL_ASID_WIDTH.W)) else None
 }
 class ICachePipeRsp_np extends Bundle{
+  private val sourceWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
   val addr = UInt(32.W)
   val data = UInt((num_fetch*32).W)
   val mask = UInt(num_fetch.W)
   val warpid = UInt(depth_warp.W)
+  val source = UInt(sourceWidth.W)
+  val wf_tag = UInt(TAG_WIDTH.W)
+  val frontend_gen = UInt(frontend_gen_width.W)
   val status = UInt(2.W)
 }
 
@@ -57,12 +66,16 @@ class pipe() extends Module{
   val flush=Wire(Bool())
 
 
-  val warp_sche=Module(new warp_scheduler)
+  val warpSchedulerDefinition =
+    Definition(new warp_scheduler(num_warp_per_subcore))
+  val warpSchedulers = Seq.fill(num_subcore)(Instance(warpSchedulerDefinition))
   //val pcfifo=Module(new PCfifo)
   val control=Module(new InstrDecodeV2)
   control.io.sm_id := sm_id
-  val operand_collector=Module(new operandCollector)
+  val gvmOperandCollector =
+    if (GVM_ENABLED) Some(Module(new operandCollector)) else None
   if (GVM_ENABLED) {
+    val operandCollector = gvmOperandCollector.get
     val gvm_xreg_init = Module(new GvmDutWarpXRegInit)
     val gvm_vreg_init = Module(new GvmDutWarpVRegInit)
     gvm_xreg_init.io.clock := clock
@@ -70,52 +83,48 @@ class pipe() extends Module{
     gvm_xreg_init.io.fire := io.warpReq.fire
     gvm_xreg_init.io.sm_id := sm_id
     gvm_xreg_init.io.hardware_warp_id := io.warpReq.bits.wid.pad(32)
-    gvm_xreg_init.io.xregs := operand_collector.io.gvmWarpXRegs.get.asUInt
+    gvm_xreg_init.io.xregs := operandCollector.io.gvmWarpXRegs.get.asUInt
     gvm_vreg_init.io.clock := clock
     gvm_vreg_init.io.reset := reset.asBool
     gvm_vreg_init.io.fire := io.warpReq.fire
     gvm_vreg_init.io.sm_id := sm_id
     gvm_vreg_init.io.hardware_warp_id := io.warpReq.bits.wid.pad(32)
-    gvm_vreg_init.io.vregs := operand_collector.io.gvmWarpVRegs.get.asUInt
+    gvm_vreg_init.io.vregs := operandCollector.io.gvmWarpVRegs.get.asUInt
 
-    operand_collector.io.gvmWarpHwId.get := io.warpReq.bits.wid
-    operand_collector.io.gvmWarpSgprBase.get := io.warpReq.bits.CTAdata.dispatch2cu_sgpr_base_dispatch
-    operand_collector.io.gvmWarpVgprBase.get := io.warpReq.bits.CTAdata.dispatch2cu_vgpr_base_dispatch
+    operandCollector.io.gvmWarpHwId.get := io.warpReq.bits.wid
+    operandCollector.io.gvmWarpSgprBase.get := io.warpReq.bits.CTAdata.dispatch2cu_sgpr_base_dispatch
+    operandCollector.io.gvmWarpVgprBase.get := io.warpReq.bits.CTAdata.dispatch2cu_vgpr_base_dispatch
+    operandCollector.io.controlX.valid := false.B
+    operandCollector.io.controlX.bits := 0.U.asTypeOf(new CtrlSigs)
+    operandCollector.io.controlV.valid := false.B
+    operandCollector.io.controlV.bits := 0.U.asTypeOf(new CtrlSigs)
+    operandCollector.io.writeVecCtrl.valid := false.B
+    operandCollector.io.writeVecCtrl.bits := 0.U.asTypeOf(new WriteVecCtrl)
+    operandCollector.io.writeScalarCtrl.valid := false.B
+    operandCollector.io.writeScalarCtrl.bits := 0.U.asTypeOf(new WriteScalarCtrl)
+    operandCollector.io.sgpr_base := VecInit(Seq.fill(num_warp)(0.U((SGPR_ID_WIDTH + 1).W)))
+    operandCollector.io.vgpr_base := VecInit(Seq.fill(num_warp)(0.U((VGPR_ID_WIDTH + 1).W)))
+    operandCollector.io.out.foreach(_.ready := true.B)
   }
-  //val issue=Module(new Issue)
-  val issueX = Module(new Issue)
-  val issueV = Module(new Issue)
-  val alu=Module(new ALUexe)
-  val valu=Module(new vALUv2(num_thread, num_lane))
-  val fpu=Module(new FPUexe(num_thread,num_lane))
-  val lsu=Module(new LSUexe)
-  val sfu=Module(new SFUexe)
-  val mul=Module(new vMULv2(num_thread,num_lane))
-  val tensorcore=Module(new vTCexe)
   val lsu2wb=Module(new LSU2WB)
-  val wb=Module(new Writeback(6,7))
 
   val inst_cnt_xv = RegInit(VecInit(0.U(32.W), 0.U(32.W)))
-  if(INST_CNT_2){
-    when(issueX.io.in.fire){
-      when(issueV.io.in.fire && !issueV.io.in.bits.ctrl.isvec){
-        inst_cnt_xv(0) := inst_cnt_xv(0) + 2.U
-      }.otherwise{
-        inst_cnt_xv(0) := inst_cnt_xv(0) + 1.U
-      }
-    }
-    when(issueV.io.in.fire){
-      when(issueV.io.in.bits.ctrl.isvec){
-        inst_cnt_xv(1) := inst_cnt_xv(1) + PopCount(issueV.io.in.bits.mask)
-      }
-    }
-  }
-
-  val scoreb=VecInit(Seq.fill(num_warp)(Module(new Scoreboard).io))
-  val ibuffer=Module(new InstrBufferV2)
-  val ibuffer2issue=Module(new ibuffer2issue)
+  val localScoreboards = Seq.fill(num_subcore)(Module(new SubcoreScoreboardBank(num_warp_per_subcore)))
+  val ibuffers = Seq.tabulate(num_subcore)(sc => Module(new InstrBufferV2(num_warp_per_subcore, sc)))
+  val ibufferRspOwner = PipeSubcoreHelpers.subcoreValue(io.icache_rsp.bits.warpid)
+  val ibufferInReady = MuxLookup(ibufferRspOwner, false.B)(
+    (0 until num_subcore).map(sc => sc.U -> ibuffers(sc).io.in.ready)
+  )
+  val ibufferReadyGlobal = VecInit((0 until num_warp).map { globalWid =>
+    val sc = globalWid & (num_subcore - 1)
+    val localWid = globalWid >> subcore_sel_bits
+    ibuffers(sc).io.ibuffer_ready(localWid)
+  })
+  val subcoreIbuffer2issue = Seq.tabulate(num_subcore)(_ =>
+    Module(new ibuffer2issue(num_warp_per_subcore))
+  )
   if(INST_CNT) {
-    io.inst_cnt.foreach(_ := ibuffer2issue.io.cnt.getOrElse(0.U))
+    io.inst_cnt.foreach(_ := subcoreIbuffer2issue.map(_.io.cnt.getOrElse(0.U)).reduce(_ +& _))
   }
   if(INST_CNT_2){
     io.inst_cnt2.foreach( _ := inst_cnt_xv)
@@ -123,73 +132,316 @@ class pipe() extends Module{
   else{
     io.inst_cnt.foreach( _ := 0.U)
   }
-  //  val exe_acq_reg=Module(new Queue(new CtrlSigs,1,pipe=true))
-  val exe_dataX=Module(new Module{
-    val io = IO(new Bundle{
-      val enq = Flipped(DecoupledIO(new vExeData))
-      val deq = DecoupledIO(Output(new vExeData))
-    })
-    io.deq <> io.enq
-  })
-  val exe_dataV = Module(new Module {
-    val io = IO(new Bundle {
-      val enq = Flipped(DecoupledIO(new vExeData))
-      val deq = DecoupledIO(Output(new vExeData))
-    })
-    io.deq <> io.enq
-  })
-  val simt_stack=Module(new branch_join(num_thread))
-  val branch_back=Module(new Branch_back)
-  val csrfile=Module(new CSRexe())
+  val frontendCtrlScaffold = Module(new FrontendCtrl)
+  val lifecycleCtrlScaffold = Module(new WarpLifecycleCtrl)
+  val localWritebacks = Seq.tabulate(num_subcore)(sc => Module(new SubcoreWritebackFabric(sc)))
+  private val activeSubcoreCount = num_subcore
+  // Full backend array. Non-memory execution and final writeback stay local;
+  // memory resources and cross-subcore control arbitration remain SM-shared.
+  val subcoreBackends = Seq.fill(activeSubcoreCount)(Module(new SubcoreBackendSlice))
+  private val subcoreIdxWidth = if (num_subcore <= 1) 1 else log2Ceil(num_subcore)
+  private val localDepthWarp = if (num_warp_per_subcore == 1) 1 else log2Ceil(num_warp_per_subcore)
+  private def globalWarpIndex(sc: Int, local: Int): Int =
+    PipeSubcoreHelpers.globalWarpIndex(sc, local)
+  private def localizeCtrl(in: CtrlSigs): CtrlSigs = {
+    val out = Wire(new CtrlSigs)
+    out := in
+    out.wid := PipeSubcoreHelpers.localWidValue(in.wid)
+    out
+  }
+  private def localizeWarpReq(in: warpReqData): warpReqData = {
+    val out = Wire(new warpReqData)
+    out := in
+    out.wid := PipeSubcoreHelpers.localWidValue(in.wid)
+    out
+  }
+  private def localizeBranch(in: BranchCtrl): BranchCtrl = {
+    val out = Wire(new BranchCtrl)
+    out := in
+    out.wid := PipeSubcoreHelpers.localWidValue(in.wid)
+    out
+  }
+  private def localizeWarpLifecycle(in: warpSchedulerExeData): warpSchedulerExeData = {
+    val out = Wire(new warpSchedulerExeData)
+    out := in
+    out.ctrl.wid := PipeSubcoreHelpers.localWidValue(in.ctrl.wid)
+    out
+  }
+  private def localizeICacheRsp(in: ICachePipeRsp_np): ICachePipeRsp_np = {
+    val out = Wire(new ICachePipeRsp_np)
+    out := in
+    out.warpid := PipeSubcoreHelpers.localWidValue(in.warpid)
+    out
+  }
+  private def restoreWarpRsp(sc: Int, in: warpRspData): warpRspData = {
+    val out = Wire(new warpRspData)
+    out := in
+    out.wid := PipeSubcoreHelpers.internalWid(sc, in.wid)
+    out
+  }
+  private def restoreICacheReq(sc: Int, in: ICachePipeReq_np): ICachePipeReq_np = {
+    val out = Wire(new ICachePipeReq_np)
+    out := in
+    out.warpid := PipeSubcoreHelpers.internalWid(sc, in.warpid)
+    out.source := sc.U
+    out
+  }
+  private def localizeWriteScalar(in: WriteScalarCtrl): WriteScalarCtrl = {
+    val out = Wire(new WriteScalarCtrl)
+    out := in
+    out.warp_id := PipeSubcoreHelpers.localWidValue(in.warp_id)
+    out
+  }
+  private def localizeWriteVec(in: WriteVecCtrl): WriteVecCtrl = {
+    val out = Wire(new WriteVecCtrl)
+    out := in
+    out.warp_id := PipeSubcoreHelpers.localWidValue(in.warp_id)
+    out
+  }
+  private def restoreBranch(sc: Int, in: BranchCtrl): BranchCtrl = {
+    val out = Wire(new BranchCtrl)
+    out := in
+    out.wid := PipeSubcoreHelpers.internalWid(sc, in.wid)
+    out
+  }
+  private def restoreWarpLifecycle(sc: Int, in: warpSchedulerExeData): warpSchedulerExeData = {
+    val out = Wire(new warpSchedulerExeData)
+    out := in
+    out.ctrl.wid := PipeSubcoreHelpers.internalWid(sc, in.ctrl.wid)
+    out
+  }
+  private val lsuLocalInstrIdWidth = log2Up(lsu_nMshrEntry)
+  private val lsuFabricSourceWidth = subcoreIdxWidth
 
-  io.externalFlushPipe.valid:=warp_sche.io.flush.valid|warp_sche.io.flushCache.valid
-  io.externalFlushPipe.bits:=Mux(warp_sche.io.flush.valid,warp_sche.io.flush.bits,warp_sche.io.flushCache.bits)
+  val acceptedBranchWid = Wire(UInt(depth_warp.W))
+  val acceptedBranchRedirect = Wire(Bool())
+  val acceptedBarrierWid = Wire(UInt(depth_warp.W))
+  val acceptedBarrier = Wire(Bool())
+  val acceptedEndprgWid = Wire(UInt(depth_warp.W))
+  val acceptedEndprg = Wire(Bool())
+  acceptedBranchWid := 0.U
+  acceptedBranchRedirect := false.B
+  acceptedBarrierWid := 0.U
+  acceptedBarrier := false.B
+  acceptedEndprgWid := 0.U
+  acceptedEndprg := false.B
+  for (sc <- 0 until num_subcore) {
+    frontendCtrlScaffold.io.flush(sc).valid := false.B
+    frontendCtrlScaffold.io.flush(sc).bits := 0.U
+    frontendCtrlScaffold.io.flush_cache(sc).valid := false.B
+    frontendCtrlScaffold.io.flush_cache(sc).bits := 0.U
 
-  csrfile.io.lsu_wid:=lsu.io.csr_wid
-  lsu.io.csr_pds:=csrfile.io.lsu_pds
-  lsu.io.csr_tid:=csrfile.io.lsu_tid
-  lsu.io.csr_numw:=csrfile.io.lsu_numw
-  lsu.io.csr_numt:=csrfile.io.lsu_numt
-  if (SPIKE_OUTPUT) {
-    when(csrfile.io.in.valid && csrfile.io.in.bits.ctrl.custom_signal_0){
-      printf(p"sm ${sm_id} warp ${Decimal(csrfile.io.in.bits.ctrl.wid)} " +
-             p"0x${Hexadecimal(csrfile.io.in.bits.ctrl.pc)} 0x${Hexadecimal(csrfile.io.in.bits.ctrl.inst)}  setrpc 0x${Hexadecimal(csrfile.io.in.bits.in1)} \n")
-    }
+    lifecycleCtrlScaffold.io.branch_jump(sc).valid :=
+      acceptedBranchRedirect && PipeSubcoreHelpers.subcoreValue(acceptedBranchWid) === sc.U
+    lifecycleCtrlScaffold.io.branch_jump(sc).bits := acceptedBranchWid
+    lifecycleCtrlScaffold.io.barrier_arrive(sc).valid :=
+      acceptedBarrier && PipeSubcoreHelpers.subcoreValue(acceptedBarrierWid) === sc.U
+    lifecycleCtrlScaffold.io.barrier_arrive(sc).bits := acceptedBarrierWid
+    lifecycleCtrlScaffold.io.endprg(sc).valid :=
+      acceptedEndprg && PipeSubcoreHelpers.subcoreValue(acceptedEndprgWid) === sc.U
+    lifecycleCtrlScaffold.io.endprg(sc).bits := acceptedEndprgWid
+
+  }
+  for (sc <- 0 until activeSubcoreCount) {
+    subcoreBackends(sc).io.subcore_id := sc.U
+    subcoreBackends(sc).io.frontend_control_v.valid := false.B
+    subcoreBackends(sc).io.frontend_control_v.bits := 0.U.asTypeOf(new CtrlSigs)
+    subcoreBackends(sc).io.frontend_control_x.valid := false.B
+    subcoreBackends(sc).io.frontend_control_x.bits := 0.U.asTypeOf(new CtrlSigs)
+    subcoreBackends(sc).io.branch_out.ready := false.B
+    subcoreBackends(sc).io.warp_lifecycle.ready := false.B
+    subcoreBackends(sc).io.lsu_dcache_req.ready := false.B
+    subcoreBackends(sc).io.lsu_dcache_rsp.valid := false.B
+    subcoreBackends(sc).io.lsu_dcache_rsp.bits := 0.U.asTypeOf(new DCacheCoreRsp_np)
+    subcoreBackends(sc).io.lsu_shared_req.ready := false.B
+    subcoreBackends(sc).io.lsu_shared_rsp.valid := false.B
+    subcoreBackends(sc).io.lsu_shared_rsp.bits := 0.U.asTypeOf(new DCacheCoreRsp_np)
+    subcoreBackends(sc).io.lsu_result_rsp.ready := false.B
+    subcoreBackends(sc).io.flush_dcache.valid := false.B
+    subcoreBackends(sc).io.flush_dcache.bits := false.B
+    subcoreBackends(sc).io.compute_valu_vec.ready := false.B
+    subcoreBackends(sc).io.compute_mul_scalar.ready := false.B
+    subcoreBackends(sc).io.compute_mul_vec.ready := false.B
+    subcoreBackends(sc).io.warp_init.valid := false.B
+    subcoreBackends(sc).io.warp_init.bits := 0.U.asTypeOf(new warpReqData)
+  }
+  frontendCtrlScaffold.io.launch_flush.valid := io.warpReq.fire
+  frontendCtrlScaffold.io.launch_flush.bits := io.warpReq.bits.wid
+  frontendCtrlScaffold.io.ibuffer_ready_for_rsp := ibufferInReady
+  val frontendFlushGlobalValid = Wire(Vec(activeSubcoreCount, Bool()))
+  val frontendFlushGlobalBits = Wire(Vec(activeSubcoreCount, UInt(depth_warp.W)))
+  val frontendFlushCacheGlobalValid = Wire(Vec(activeSubcoreCount, Bool()))
+  val frontendFlushCacheGlobalBits = Wire(Vec(activeSubcoreCount, UInt(depth_warp.W)))
+  for (sc <- 0 until activeSubcoreCount) {
+    frontendFlushGlobalValid(sc) := false.B
+    frontendFlushGlobalBits(sc) := 0.U
+    frontendFlushCacheGlobalValid(sc) := false.B
+    frontendFlushCacheGlobalBits(sc) := 0.U
+  }
+  val anyFrontendFlushGlobal = frontendFlushGlobalValid.asUInt.orR
+  val anyFrontendFlushCacheGlobal = frontendFlushCacheGlobalValid.asUInt.orR
+  val frontendFlushGlobalWid = PriorityMux(
+    (0 until activeSubcoreCount).map(sc => frontendFlushGlobalValid(sc) -> frontendFlushGlobalBits(sc))
+  )
+  val frontendFlushCacheGlobalWid = PriorityMux(
+    (0 until activeSubcoreCount).map(sc => frontendFlushCacheGlobalValid(sc) -> frontendFlushCacheGlobalBits(sc))
+  )
+  val frontendRspKillFlushValid = RegNext(anyFrontendFlushGlobal, false.B)
+  val frontendRspKillFlushBits = RegNext(frontendFlushGlobalWid, 0.U(depth_warp.W))
+  frontendCtrlScaffold.io.rsp_kill.valid := frontendRspKillFlushValid
+  frontendCtrlScaffold.io.rsp_kill.bits := frontendRspKillFlushBits
+  frontendCtrlScaffold.io.wg_tag_lookup := lifecycleCtrlScaffold.io.wg_tag_lookup
+  frontendCtrlScaffold.io.frontend_gen_lookup := lifecycleCtrlScaffold.io.frontend_gen_lookup
+  frontendCtrlScaffold.io.recently_freed := lifecycleCtrlScaffold.io.recently_freed
+
+  lifecycleCtrlScaffold.io.launch.valid := io.warpReq.fire
+  lifecycleCtrlScaffold.io.launch.bits.wid := io.warpReq.bits.wid
+  lifecycleCtrlScaffold.io.launch.bits.wf_tag := io.warpReq.bits.CTAdata.dispatch2cu_wf_tag_dispatch
+  lifecycleCtrlScaffold.io.launch.bits.wg_wf_count := io.warpReq.bits.CTAdata.dispatch2cu_wg_wf_count
+  lifecycleCtrlScaffold.io.complete.valid := io.warpRsp.fire
+  lifecycleCtrlScaffold.io.complete.bits := io.warpRsp.bits.wid
+
+  for (sc <- 0 until activeSubcoreCount) {
+    val warpInit = subcoreBackends(sc).io.warp_init
+    warpInit.valid := warpSchedulers(sc).io.CTA2csr.valid
+    warpInit.bits := warpSchedulers(sc).io.CTA2csr.bits
   }
 
-  warp_sche.io.pc_reset:=io.pc_reset
-  warp_sche.io.branch<>branch_back.io.out
-  //warp_sche.io.pc_icache_ready:=pcfifo.io.icachebuf_ready
-  warp_sche.io.pc_ibuffer_ready:=ibuffer.io.ibuffer_ready
-  warp_sche.io.wg_id_tag:=io.wg_id_tag
-  io.wg_id_lookup:=warp_sche.io.wg_id_lookup
-  warp_sche.io.pc_rsp.valid:=io.icache_rsp.valid
-  warp_sche.io.pc_rsp.bits:=io.icache_rsp.bits
-  warp_sche.io.pc_rsp.bits.status:=Mux(ibuffer.io.in.ready,io.icache_rsp.bits.status,1.U(2.W))
+  val resultFabric = Module(new PipeExecutionResultFabric(activeSubcoreCount))
 
-  warp_sche.io.pc_req<>io.icache_req
-  warp_sche.io.warp_control<>issueX.io.out_warpscheduler
-  warp_sche.io.issued_warp.bits:=exe_dataX.io.enq.bits.ctrl.wid // not used
-  warp_sche.io.issued_warp.valid:=exe_dataX.io.enq.fire // not used
-  val scoreboardBusy = (VecInit(scoreb.map(_.delay))).asUInt
-  warp_sche.io.scoreboard_busy:=scoreboardBusy
+  for (sc <- 0 until activeSubcoreCount) {
+    resultFabric.io.lifecycleIn(sc).valid := subcoreBackends(sc).io.warp_lifecycle.valid
+    resultFabric.io.lifecycleIn(sc).bits := restoreWarpLifecycle(sc, subcoreBackends(sc).io.warp_lifecycle.bits)
+    subcoreBackends(sc).io.warp_lifecycle.ready := resultFabric.io.lifecycleIn(sc).ready
 
-  csrfile.io.CTA2csr:=warp_sche.io.CTA2csr
-  val init_thread_mask = (1.U(num_thread.W) << warp_sche.io.CTA2csr.bits.CTAdata.dispatch2cu_wf_size_dispatch).asUInt - 1.U
-  simt_stack.io.initMask.valid := warp_sche.io.CTA2csr.valid
-  simt_stack.io.initMask.bits.warp_id := warp_sche.io.CTA2csr.bits.wid
-  simt_stack.io.initMask.bits.thread_mask := init_thread_mask
-  when(warp_sche.io.CTA2csr.fire){
-    printf(p"sm ${sm_id} warp ${Decimal(warp_sche.io.CTA2csr.bits.wid)} init thread mask 0x${Hexadecimal(init_thread_mask)}\n")
+    resultFabric.io.aluBranchIn(sc).valid := subcoreBackends(sc).io.branch_out.valid
+    resultFabric.io.aluBranchIn(sc).bits := restoreBranch(sc, subcoreBackends(sc).io.branch_out.bits)
+    subcoreBackends(sc).io.branch_out.ready := resultFabric.io.aluBranchIn(sc).ready
+
+    val wb = localWritebacks(sc)
+    wb.io.alu_scalar <> subcoreBackends(sc).io.compute_alu_scalar
+    wb.io.fpu_scalar <> subcoreBackends(sc).io.compute_fpu_scalar
+    wb.io.csr_scalar <> subcoreBackends(sc).io.csr_scalar
+    wb.io.sfu_scalar <> subcoreBackends(sc).io.compute_sfu_scalar
+    wb.io.mul_scalar <> subcoreBackends(sc).io.compute_mul_scalar
+    wb.io.valu_vec <> subcoreBackends(sc).io.compute_valu_vec
+    wb.io.fpu_vec <> subcoreBackends(sc).io.compute_fpu_vec
+    wb.io.sfu_vec <> subcoreBackends(sc).io.compute_sfu_vec
+    wb.io.mul_vec <> subcoreBackends(sc).io.compute_mul_vec
+    wb.io.tc_vec <> subcoreBackends(sc).io.compute_tc_vec
+    wb.io.csr_vec <> subcoreBackends(sc).io.csr_vec
+    subcoreBackends(sc).io.write_scalar <> wb.io.write_scalar
+    subcoreBackends(sc).io.write_vec <> wb.io.write_vec
   }
-  operand_collector.io.sgpr_base:=csrfile.io.sgpr_base
-  operand_collector.io.vgpr_base:=csrfile.io.vgpr_base
-  warp_sche.io.warpReq<>io.warpReq
-  warp_sche.io.warpRsp<>io.warpRsp
-  warp_sche.io.flushDCache <> lsu.io.flush_dcache
+
+  val sharedLsuFenceEnd = VecInit((0 until num_warp).map { globalWid =>
+    val sc = globalWid & (num_subcore - 1)
+    val localWid = globalWid >> subcore_sel_bits
+    subcoreBackends(sc).io.lsu_fence_end(localWid)
+  }).asUInt
+
+  io.externalFlushPipe.valid:=anyFrontendFlushGlobal|anyFrontendFlushCacheGlobal
+  io.externalFlushPipe.bits:=Mux(anyFrontendFlushGlobal,frontendFlushGlobalWid,frontendFlushCacheGlobalWid)
+
+  io.icache_req<>frontendCtrlScaffold.io.icache_req
+  frontendCtrlScaffold.io.icache_rsp<>io.icache_rsp
+  val scoreboardBusy = VecInit((0 until num_warp).map { globalWid =>
+    val sc = globalWid & (num_subcore - 1)
+    val localWid = globalWid >> subcore_sel_bits
+    localScoreboards(sc).io.warp(localWid).delay
+  }).asUInt
+  val warpReqOwner = PipeSubcoreHelpers.subcoreValue(io.warpReq.bits.wid)
+  val localWarpReq = localizeWarpReq(io.warpReq.bits)
+  val branchOwner = PipeSubcoreHelpers.subcoreValue(resultFabric.io.aluBranchOut.bits.wid)
+  val lifecycleOwner = PipeSubcoreHelpers.subcoreValue(resultFabric.io.lifecycleOut.bits.ctrl.wid)
+  val lifecycleIsEndprg = resultFabric.io.lifecycleOut.bits.ctrl.simt_stack_op
+  val warpRspArb = Module(new RRArbiter(new warpRspData, activeSubcoreCount))
+
+  for (sc <- 0 until activeSubcoreCount) {
+    val sched = warpSchedulers(sc)
+    sched.io.pc_reset := io.pc_reset
+    sched.io.warpReq.valid := io.warpReq.valid && warpReqOwner === sc.U
+    sched.io.warpReq.bits := localWarpReq
+    sched.io.branch.valid := resultFabric.io.aluBranchOut.valid && branchOwner === sc.U
+    sched.io.branch.bits := localizeBranch(resultFabric.io.aluBranchOut.bits)
+    sched.io.warp_control.valid := resultFabric.io.lifecycleOut.valid &&
+      lifecycleIsEndprg && lifecycleOwner === sc.U
+    sched.io.warp_control.bits := localizeWarpLifecycle(resultFabric.io.lifecycleOut.bits)
+    sched.io.pc_ibuffer_ready := VecInit((0 until num_warp_per_subcore).map { local =>
+      ibuffers(sc).io.ibuffer_ready(local).asUInt
+    })
+    sched.io.scoreboard_busy := VecInit((0 until num_warp_per_subcore).map { local =>
+      localScoreboards(sc).io.warp(local).delay ||
+        lifecycleCtrlScaffold.io.global_barrier_wait(globalWarpIndex(sc, local))
+    }).asUInt
+    sched.io.exe_busy := 0.U
+    sched.io.issued_warp.valid := false.B
+    sched.io.issued_warp.bits := 0.U
+    sched.io.pc_rsp.valid := frontendCtrlScaffold.io.pc_rsp(sc).valid
+    sched.io.pc_rsp.bits := localizeICacheRsp(frontendCtrlScaffold.io.pc_rsp(sc).bits)
+    sched.io.pc_rsp.bits.status := Mux(
+      ibuffers(sc).io.in.ready,
+      frontendCtrlScaffold.io.pc_rsp(sc).bits.status,
+      1.U(2.W)
+    )
+    val restoredPcReq = restoreICacheReq(sc, sched.io.pc_req.bits)
+    frontendCtrlScaffold.io.pc_req(sc).valid := sched.io.pc_req.valid
+    frontendCtrlScaffold.io.pc_req(sc).bits := restoredPcReq
+    sched.io.pc_req.ready := frontendCtrlScaffold.io.pc_req(sc).ready
+    frontendCtrlScaffold.io.flush(sc) := sched.io.flush
+    frontendCtrlScaffold.io.flush_cache(sc) := sched.io.flushCache
+    frontendFlushGlobalValid(sc) := sched.io.flush.valid
+    frontendFlushGlobalBits(sc) := PipeSubcoreHelpers.internalWid(sc, sched.io.flush.bits)
+    frontendFlushCacheGlobalValid(sc) := sched.io.flushCache.valid
+    frontendFlushCacheGlobalBits(sc) := PipeSubcoreHelpers.internalWid(sc, sched.io.flushCache.bits)
+    sched.io.wg_id_tag := lifecycleCtrlScaffold.io.wg_tag_lookup(
+      PipeSubcoreHelpers.internalWid(sc, sched.io.wg_id_lookup)
+    )
+    sched.io.flushDCache.ready := false.B
+
+    warpRspArb.io.in(sc).valid := sched.io.warpRsp.valid
+    warpRspArb.io.in(sc).bits := restoreWarpRsp(sc, sched.io.warpRsp.bits)
+    sched.io.warpRsp.ready := warpRspArb.io.in(sc).ready
+  }
+  io.warpReq.ready := MuxLookup(warpReqOwner, false.B)(
+    (0 until activeSubcoreCount).map(sc => sc.U -> warpSchedulers(sc).io.warpReq.ready)
+  )
+  resultFabric.io.aluBranchOut.ready := MuxLookup(branchOwner, false.B)(
+    (0 until activeSubcoreCount).map(sc => sc.U -> warpSchedulers(sc).io.branch.ready)
+  )
+  resultFabric.io.lifecycleOut.ready := Mux(
+    lifecycleIsEndprg,
+    MuxLookup(lifecycleOwner, false.B)(
+      (0 until activeSubcoreCount).map(sc => sc.U -> warpSchedulers(sc).io.warp_control.ready)
+    ),
+    true.B
+  )
+  io.warpRsp <> warpRspArb.io.out
+
+  acceptedBranchWid := resultFabric.io.aluBranchOut.bits.wid
+  acceptedBranchRedirect := resultFabric.io.aluBranchOut.fire && resultFabric.io.aluBranchOut.bits.jump
+  acceptedBarrierWid := resultFabric.io.lifecycleOut.bits.ctrl.wid
+  acceptedBarrier := resultFabric.io.lifecycleOut.fire && !lifecycleIsEndprg
+  acceptedEndprgWid := resultFabric.io.lifecycleOut.bits.ctrl.wid
+  acceptedEndprg := resultFabric.io.lifecycleOut.fire && lifecycleIsEndprg
+  io.wg_id_lookup := lifecycleCtrlScaffold.io.wg_id_lookup
+
+  val init_thread_mask = (1.U(num_thread.W) << io.warpReq.bits.CTAdata.dispatch2cu_wf_size_dispatch).asUInt - 1.U
+  when(io.warpReq.fire){
+    printf(p"sm ${sm_id} warp ${Decimal(io.warpReq.bits.wid)} init thread mask 0x${Hexadecimal(init_thread_mask)}\n")
+  }
+  val activeSubcoreFlushReady = VecInit((0 until activeSubcoreCount).map { sc =>
+    subcoreBackends(sc).io.flush_dcache.ready
+  }).asUInt.andR
+  for (sc <- 0 until activeSubcoreCount) {
+    subcoreBackends(sc).io.flush_dcache.valid :=
+      lifecycleCtrlScaffold.io.flush_dcache.valid && activeSubcoreFlushReady
+    subcoreBackends(sc).io.flush_dcache.bits := lifecycleCtrlScaffold.io.flush_dcache.bits
+  }
+  lifecycleCtrlScaffold.io.flush_dcache.ready := activeSubcoreFlushReady
 
   //flush:=(warp_sche.io.branch.fire&warp_sche.io.branch.bits.jump) | ()
-  flush:=warp_sche.io.flush.valid
+  flush:=anyFrontendFlushGlobal
 
   control.io.sm_id := sm_id
   control.io.pc:=io.icache_rsp.bits.addr
@@ -197,18 +449,32 @@ class pipe() extends Module{
     ins := (io.icache_rsp.bits.data >> (xLen * i))(xLen - 1, 0)
   }
   control.io.wid:=io.icache_rsp.bits.warpid
-  control.io.inst_mask:=Mux(io.icache_rsp.valid& !io.icache_rsp.bits.status(0),io.icache_rsp.bits.mask.asTypeOf(control.io.inst_mask),0.U.asTypeOf(control.io.inst_mask))
-  control.io.flush_wid := warp_sche.io.flush
-  control.io.ibuffer_ready := ibuffer.io.ibuffer_ready
-  ibuffer.io.in.bits.control := control.io.control
-  ibuffer.io.in.bits.control_mask := control.io.control_mask
-  ibuffer.io.in.valid:=io.icache_rsp.valid& !io.icache_rsp.bits.status(0)
+  control.io.inst_mask:=Mux(
+    frontendCtrlScaffold.io.accept_icache_rsp & !io.icache_rsp.bits.status(0),
+    io.icache_rsp.bits.mask.asTypeOf(control.io.inst_mask),
+    0.U.asTypeOf(control.io.inst_mask)
+  )
+  val frontendFlushForDecode = frontendCtrlScaffold.io.frontend_flush_mask
+  control.io.flush_wid := frontendFlushForDecode
+  control.io.ibuffer_ready := ibufferReadyGlobal
+  for (sc <- 0 until activeSubcoreCount) {
+    ibuffers(sc).io.in.bits.control := VecInit(control.io.control.map(localizeCtrl))
+    ibuffers(sc).io.in.bits.control_mask := control.io.control_mask
+    ibuffers(sc).io.in.valid := frontendCtrlScaffold.io.accept_icache_rsp &&
+      !io.icache_rsp.bits.status(0) && ibufferRspOwner === sc.U
+  }
   if(MMU_ENABLED) {
-    for (i <- 0 until num_fetch) {
-      ibuffer.io.in.bits.control(i).asid.get := warp_sche.io.asid.get
+    for (sc <- 0 until activeSubcoreCount) {
+      for (i <- 0 until num_fetch) {
+        ibuffers(sc).io.in.bits.control(i).asid.get := warpSchedulers(sc).io.asid.get
+      }
     }
   }
-  ibuffer.io.flush_wid:=warp_sche.io.flush
+  for (sc <- 0 until activeSubcoreCount) {
+    ibuffers(sc).io.flush_wid := VecInit((0 until num_warp_per_subcore).map { localWid =>
+      frontendFlushForDecode(globalWarpIndex(sc, localWid))
+    }).asUInt
+  }
 
   // 进入ibuffer的指令不一定会被实际发射执行，这里不应检测undefined instruction
   // 例如，指令段之后的一些无用数据也可能进入ibuffer，但实际上因跳转/endprg而不会发射
@@ -226,102 +492,85 @@ class pipe() extends Module{
     control.io.inst(0) := VecInit(io.inst.get.bits, 0.U(xLen.W))
     control.io.inst_mask := VecInit(1.U(1.W), 0.U(1.W))
     control.io.wid:=0.U
-    io.inst.map(_.ready:=ibuffer.io.in.ready)
-    ibuffer.io.in.valid:=io.inst.get.valid
+    io.inst.map(_.ready := ibuffers(0).io.in.ready)
+    for (sc <- 0 until activeSubcoreCount) {
+      ibuffers(sc).io.in.valid := Mux(sc.U === 0.U, io.inst.get.valid, false.B)
+    }
     when(io.inst.get.fire) {printf(p"${Hexadecimal(control.io.inst(0))}\n")}
   }
 
-  io.icache_rsp.ready:=ibuffer.io.in.ready
-
   //val ibuffer_ready=Wire(Vec(num_warp,Bool()))
-  warp_sche.io.exe_busy:= VecInit(Seq.fill(num_warp)(false.B)).asUInt //~ibuffer_ready.asUInt
+  val branchScoreboardClearMask = Mux(
+    resultFabric.io.aluBranchOut.fire,
+    UIntToOH(resultFabric.io.aluBranchOut.bits.wid, num_warp),
+    0.U(num_warp.W)
+  )
+  val warpControlScoreboardClearMask = Mux(
+    resultFabric.io.lifecycleOut.fire,
+    UIntToOH(resultFabric.io.lifecycleOut.bits.ctrl.wid, num_warp),
+    0.U(num_warp.W)
+  )
+  for (sc <- 0 until activeSubcoreCount) {
+    val backendEvents = subcoreBackends(sc).io.scoreboard
+    val localIbuf = subcoreIbuffer2issue(sc)
+    val localWriteScalar = localWritebacks(sc).io.write_scalar
+    val localWriteVec = localWritebacks(sc).io.write_vec
+    for (localWid <- 0 until num_warp_per_subcore) {
+      val globalWid = globalWarpIndex(sc, localWid)
+      val scoreboard = localScoreboards(sc).io.warp(localWid)
+      val issueXFire = localIbuf.io.out_x.fire && localIbuf.io.out_x.bits.wid === localWid.U
+      val issueVFire = localIbuf.io.out_v.fire && localIbuf.io.out_v.bits.wid === localWid.U
 
-  for (i <- 0 until num_warp) {
-    ibuffer2issue.io.in(i).bits:=ibuffer.io.out(i).bits
-    ibuffer2issue.io.in(i).valid:=ibuffer.io.out(i).valid & warp_sche.io.warp_ready(i)
-    ibuffer.io.out(i).ready:=ibuffer2issue.io.in(i).ready & warp_sche.io.warp_ready(i)
-    if(SINGLE_INST) {ibuffer2issue.io.in(i).valid:=ibuffer.io.out(i).valid & !scoreb(i).delay
-      ibuffer.io.out(i).ready:=ibuffer2issue.io.in(i).ready & !scoreb(i).delay}
-    val ctrl=ibuffer.io.out(i).bits
-    /*ibuffer_ready(i):=Mux(ctrl.sfu,sfu.io.in.ready,
-      Mux(ctrl.fp,fpu.io.in.ready,
-        Mux(ctrl.csr.orR,csrfile.io.in.ready,
-          Mux(ctrl.mem,lsu.io.lsu_req.ready,
-            Mux(ctrl.isvec&ctrl.simt_stack&ctrl.simt_stack_op===0.U,valu.io.in.ready&simt_stack.io.branch_ctl.ready,
-              Mux(ctrl.isvec&ctrl.simt_stack,simt_stack.io.branch_ctl.ready,
-                Mux(ctrl.isvec,valu.io.in.ready,
-                  Mux(ctrl.barrier,warp_sche.io.warp_control.ready,alu.io.in.ready))))))))*/
-    //when(!ibuffer.io.out(i).valid){ibuffer_ready(i):=false.B}
-    scoreb(i).ibuffer_if_ctrl:=ibuffer.io.out(i).bits
-    scoreb(i).if_ctrl:= Mux((i.asUInt === ibuffer2issue.io.out_x.bits.wid) && ibuffer2issue.io.out_x.fire, ibuffer2issue.io.out_x.bits,ibuffer2issue.io.out_v.bits)
-    scoreb(i).wb_v_ctrl:=wb.io.out_v.bits
-    scoreb(i).wb_x_ctrl:=wb.io.out_x.bits
-    scoreb(i).fence_end:=lsu.io.fence_end(i)
-    scoreb(i).if_fire:=Mux(((i.asUInt===ibuffer2issue.io.out_x.bits.wid)&&ibuffer2issue.io.out_x.fire) ||
-      ((i.asUInt===ibuffer2issue.io.out_v.bits.wid)&&ibuffer2issue.io.out_v.fire), true.B,false.B)
-    scoreb(i).wb_v_fire:=false.B
-    scoreb(i).wb_x_fire:=false.B
-    scoreb(i).br_ctrl:=false.B
-    scoreb(i).op_colX_in_fire:=false.B
-    scoreb(i).op_colX_out_fire:=false.B
-    scoreb(i).op_colV_in_fire := false.B
-    scoreb(i).op_colV_out_fire := false.B
-
-    when(warp_sche.io.branch.fire&(warp_sche.io.branch.bits.wid===i.asUInt)){scoreb(i).br_ctrl:=true.B}.
-      elsewhen(warp_sche.io.warp_control.fire&(warp_sche.io.warp_control.bits.ctrl.wid===i.asUInt)){scoreb(i).br_ctrl:=true.B}.
-      elsewhen(simt_stack.io.complete.valid&(simt_stack.io.complete.bits===i.asUInt)){scoreb(i).br_ctrl:=true.B}
-  }
-  val op_colV_in_wid = Wire(UInt(depth_warp.W))
-  val op_colV_out_wid = Wire(UInt(depth_warp.W))
-  val op_colX_in_wid = Wire(UInt(depth_warp.W))
-  val op_colX_out_wid = Wire(UInt(depth_warp.W))
-  op_colV_in_wid := operand_collector.io.controlV.bits.wid
-  op_colV_out_wid := operand_collector.io.out(0).bits.control.wid
-  scoreb(op_colV_in_wid).op_colV_in_fire:=operand_collector.io.controlV.fire
-  scoreb(op_colV_out_wid).op_colV_out_fire:=operand_collector.io.out(0).fire
-
-  op_colX_in_wid := operand_collector.io.controlX.bits.wid
-  op_colX_out_wid := operand_collector.io.out(1).bits.control.wid
-  scoreb(op_colX_in_wid).op_colX_in_fire := operand_collector.io.controlX.fire
-  scoreb(op_colX_out_wid).op_colX_out_fire := operand_collector.io.out(1).fire
-
-
-  scoreb(wb.io.out_x.bits.warp_id).wb_x_fire:=wb.io.out_x.fire
-  scoreb(wb.io.out_v.bits.warp_id).wb_v_fire:=wb.io.out_v.fire
-
-  // ibuffer2issue模块的IO都是实际发射但尚未执行的指令，在这检查undefined instruction
-  when(ibuffer2issue.io.out_x.fire){
-    val ctrl = ibuffer2issue.io.out_x.bits
-    assert(ctrl.alu_fn =/= 63.U, 
-           p"UNDEFINED INSTRUCTION @ SM ${sm_id} warp ${Decimal(ctrl.wid)} " + 
-           p"PC 0x${Hexadecimal(ctrl.pc)}: 0x${Hexadecimal(ctrl.inst)}")
-  }
-  when(ibuffer2issue.io.out_v.fire){
-    val ctrl = ibuffer2issue.io.out_v.bits
-    assert(ctrl.alu_fn =/= 63.U, 
-           p"UNDEFINED INSTRUCTION @ SM ${sm_id} warp ${Decimal(ctrl.wid)} " + 
-           p"PC 0x${Hexadecimal(ctrl.pc)}: 0x${Hexadecimal(ctrl.inst)}")
+      scoreboard.ibuffer_if_ctrl := ibuffers(sc).io.out(localWid).bits
+      scoreboard.if_ctrl := Mux(issueXFire, localIbuf.io.out_x.bits, localIbuf.io.out_v.bits)
+      scoreboard.wb_v_ctrl := localWriteVec.bits
+      scoreboard.wb_x_ctrl := localWriteScalar.bits
+      scoreboard.fence_end := sharedLsuFenceEnd(globalWid)
+      scoreboard.if_fire := issueXFire || issueVFire
+      scoreboard.wb_v_fire := localWriteVec.fire && localWriteVec.bits.warp_id === localWid.U
+      scoreboard.wb_x_fire := localWriteScalar.fire && localWriteScalar.bits.warp_id === localWid.U
+      scoreboard.br_ctrl := branchScoreboardClearMask(globalWid) ||
+        warpControlScoreboardClearMask(globalWid) ||
+        (backendEvents.simt_complete_fire && backendEvents.simt_complete_wid === localWid.U)
+      scoreboard.op_colX_in_fire :=
+        backendEvents.op_col_x_in_fire && backendEvents.op_col_x_in_wid === localWid.U
+      scoreboard.op_colX_out_fire :=
+        backendEvents.op_col_x_out_fire && backendEvents.op_col_x_out_wid === localWid.U
+      scoreboard.op_colV_in_fire :=
+        backendEvents.op_col_v_in_fire && backendEvents.op_col_v_in_wid === localWid.U
+      scoreboard.op_colV_out_fire :=
+        backendEvents.op_col_v_out_fire && backendEvents.op_col_v_out_wid === localWid.U
+    }
   }
 
-  operand_collector.io.controlV<>ibuffer2issue.io.out_v//ibuffer2issue.io.out.bits
-  operand_collector.io.controlX<>ibuffer2issue.io.out_x//ibuffer2issue.io.out.bits
-  operand_collector.io.writeVecCtrl<>wb.io.out_v
-  operand_collector.io.writeScalarCtrl<>wb.io.out_x
-
-  simt_stack.io.input_wid:=operand_collector.io.out(0).bits.control.wid//ibuffer2issue.io.out.bits.wid
-  csrfile.io.simt_wid := operand_collector.io.out(0).bits.control.wid // todo check this
+  // Per-subcore backend main path.
+  for (sc <- 0 until activeSubcoreCount) {
+    val localIbuf = subcoreIbuffer2issue(sc)
+    val backend = subcoreBackends(sc)
+    for (localWid <- 0 until num_warp_per_subcore) {
+      val globalWid = globalWarpIndex(sc, localWid)
+      localIbuf.io.in(localWid).bits := ibuffers(sc).io.out(localWid).bits
+      localIbuf.io.in(localWid).valid :=
+        ibuffers(sc).io.out(localWid).valid && warpSchedulers(sc).io.warp_ready(localWid)
+      ibuffers(sc).io.out(localWid).ready :=
+        localIbuf.io.in(localWid).ready && warpSchedulers(sc).io.warp_ready(localWid)
+    }
+    backend.io.frontend_control_x <> localIbuf.io.out_x
+    backend.io.frontend_control_v <> localIbuf.io.out_v
+    Seq(localIbuf.io.out_x, localIbuf.io.out_v).foreach { issued =>
+      when(issued.fire) {
+        assert(issued.bits.alu_fn =/= 63.U,
+          p"UNDEFINED INSTRUCTION @ SM ${sm_id} warp ${Decimal(issued.bits.wid)} " +
+          p"PC 0x${Hexadecimal(issued.bits.pc)}: 0x${Hexadecimal(issued.bits.inst)}")
+      }
+    }
+  }
 
   when(io.icache_req.fire&(io.icache_req.bits.warpid===2.U)){
     //printf(p"wid=${io.icache_req.bits.warpid},pc=0x${Hexadecimal(io.icache_req.bits.addr)}\n")
   }
   when(io.icache_rsp.fire&(io.icache_rsp.bits.warpid===2.U)){
     //printf(p"wid=${io.icache_rsp.bits.warpid},pc=0x${Hexadecimal(io.icache_rsp.bits.addr)},inst=0x${Hexadecimal(io.icache_rsp.bits.data)}\n")
-  }
-  when(exe_dataX.io.deq.fire&(exe_dataX.io.deq.bits.ctrl.wid===2.U)){
-    //printf(p"wid=${exe_dataX.io.deq.bits.ctrl.wid},pc=0x${Hexadecimal(exe_dataX.io.deq.bits.ctrl.pc)},inst=0x${Hexadecimal(exe_dataX.io.deq.bits.ctrl.inst)}\n")
-  }
-  when(exe_dataV.io.deq.fire&(exe_dataV.io.deq.bits.ctrl.wid===2.U)) {
-    //printf(p"wid=${exe_dataV.io.deq.bits.ctrl.wid},pc=0x${Hexadecimal(exe_dataV.io.deq.bits.ctrl.pc)},inst=0x${Hexadecimal(exe_dataV.io.deq.bits.ctrl.inst)}\n")
   }
 
 
@@ -368,82 +617,46 @@ class pipe() extends Module{
   //    printf(p"write x${wb.io.out_x.bits.reg_idxw} 0x${Hexadecimal(wb.io.out_x.bits.wb_wxd_rd)}\n")
   //  }
 
-  {
-    exe_dataX.io.enq.bits.ctrl := operand_collector.io.out(1).bits.control
-    exe_dataX.io.enq.bits.in1 := operand_collector.io.out(1).bits.alu_src1
-    exe_dataX.io.enq.bits.in2 := operand_collector.io.out(1).bits.alu_src2
-    exe_dataX.io.enq.bits.in3 := operand_collector.io.out(1).bits.alu_src3
-    exe_dataX.io.enq.bits.mask.foreach(_ := true.B)
-    exe_dataX.io.enq.valid:=operand_collector.io.out(1).valid
-    operand_collector.io.out(1).ready := exe_dataX.io.enq.ready
-
-    exe_dataV.io.enq.bits.ctrl := operand_collector.io.out(0).bits.control
-    exe_dataV.io.enq.bits.in1 := operand_collector.io.out(0).bits.alu_src1
-    exe_dataV.io.enq.bits.in2 := operand_collector.io.out(0).bits.alu_src2
-    exe_dataV.io.enq.bits.in3 := operand_collector.io.out(0).bits.alu_src3
-    exe_dataV.io.enq.bits.mask := (operand_collector.io.out(0).bits.mask.zipWithIndex.map { case (x, y) => x & simt_stack.io.out_mask(y) })
-    exe_dataV.io.enq.valid := operand_collector.io.out(0).valid
-    operand_collector.io.out(0).ready := exe_dataV.io.enq.ready
+  val sharedLsuFabric = Module(new PipeSharedLsuFabric(activeSubcoreCount, lsuFabricSourceWidth, lsuLocalInstrIdWidth))
+  for (sc <- 0 until activeSubcoreCount) {
+    sharedLsuFabric.io.subcore(sc).dcache_req <> subcoreBackends(sc).io.lsu_dcache_req
+    subcoreBackends(sc).io.lsu_dcache_rsp <> sharedLsuFabric.io.subcore(sc).dcache_rsp
+    sharedLsuFabric.io.subcore(sc).shared_req <> subcoreBackends(sc).io.lsu_shared_req
+    subcoreBackends(sc).io.lsu_shared_rsp <> sharedLsuFabric.io.subcore(sc).shared_rsp
+    sharedLsuFabric.io.subcore(sc).lsu_rsp <> subcoreBackends(sc).io.lsu_result_rsp
   }
-  //  exe_acq_reg.io.deq.ready:=exe_data.io.enq.ready//ibuffer2issue.io.out.ready:=exe_data.io.enq.ready
-  issueV.io.in<>exe_dataV.io.deq
-  issueX.io.in<>exe_dataX.io.deq
 
-  issueV.io.out_vALU<>valu.io.in
-  issueX.io.out_vALU.ready := false.B
-  issueV.io.out_LSU<>lsu.io.lsu_req
-  issueX.io.out_LSU.ready := false.B
-  issueX.io.out_sALU<>alu.io.in
-  issueV.io.out_sALU.ready := false.B
-  issueX.io.out_CSR<>csrfile.io.in
-  issueV.io.out_CSR.ready := false.B
-  issueV.io.out_SIMT<>simt_stack.io.branch_ctl
-  issueX.io.out_SIMT.ready := false.B
-  issueV.io.out_SFU<>sfu.io.in
-  issueX.io.out_SFU.ready := false.B
-  //simt_stack.io.branch_ctl<>Queue(issue.io.out_SIMT,1,flow = true)
-  simt_stack.io.if_mask<>valu.io.out2simt_stack
-  simt_stack.io.fetch_ctl<>branch_back.io.in1
-  simt_stack.io.pc_reconv.bits := csrfile.io.simt_rpc
-  simt_stack.io.pc_reconv.valid := issueV.io.out_SIMT.valid//true.B //todo check this
+  io.dcache_req.valid := sharedLsuFabric.io.sm_dcache_req.valid
+  io.dcache_req.bits := sharedLsuFabric.io.sm_dcache_req.bits
+  sharedLsuFabric.io.sm_dcache_req.ready := io.dcache_req.ready
+  sharedLsuFabric.io.sm_dcache_rsp.valid := io.dcache_rsp.valid
+  sharedLsuFabric.io.sm_dcache_rsp.bits := io.dcache_rsp.bits
+  io.dcache_rsp.ready := sharedLsuFabric.io.sm_dcache_rsp.ready
+  io.shared_req.valid := sharedLsuFabric.io.sm_shared_req.valid
+  io.shared_req.bits := sharedLsuFabric.io.sm_shared_req.bits
+  sharedLsuFabric.io.sm_shared_req.ready := io.shared_req.ready
+  sharedLsuFabric.io.sm_shared_rsp.valid := io.shared_rsp.valid
+  sharedLsuFabric.io.sm_shared_rsp.bits := io.shared_rsp.bits
+  io.shared_rsp.ready := sharedLsuFabric.io.sm_shared_rsp.ready
+  sharedLsuFabric.io.lsu2wb_lsu_rsp <> lsu2wb.io.lsu_rsp
 
-  alu.io.out2br<>branch_back.io.in0
-
-  issueV.io.out_MUL<>mul.io.in
-  issueX.io.out_MUL.ready := false.B
-  issueV.io.out_TC<>tensorcore.io.in
-  issueX.io.out_TC.ready := false.B
-  issueV.io.out_vFPU<>fpu.io.in
-  issueX.io.out_vFPU.ready := false.B
-  issueX.io.out_warpscheduler <> warp_sche.io.warp_control
-  issueV.io.out_warpscheduler.ready := false.B
-
-  fpu.io.rm := Mux(fpu.io.in.bits.ctrl.force_rm_rtz, RoundingMode.RTZ, csrfile.io.rm(0))
-  csrfile.io.rm_wid(0):=fpu.io.in.bits.ctrl.wid
-  sfu.io.rm := csrfile.io.rm(1)
-  csrfile.io.rm_wid(1):=sfu.io.in.bits.ctrl.wid
-  tensorcore.io.rm := csrfile.io.rm(2)
-  csrfile.io.rm_wid(2):=tensorcore.io.in.bits.ctrl.wid
-
-  lsu.io.dcache_rsp<>io.dcache_rsp
-  lsu.io.dcache_req<>io.dcache_req
-  lsu.io.lsu_rsp<>lsu2wb.io.lsu_rsp
-  lsu.io.shared_rsp<>io.shared_rsp
-  lsu.io.shared_req<>io.shared_req
-
-  wb.io.in_x(0)<>alu.io.out
-  wb.io.in_x(1)<>fpu.io.out_x
-  wb.io.in_x(2)<>lsu2wb.io.out_x
-  wb.io.in_x(3)<>csrfile.io.out
-  wb.io.in_x(4)<>sfu.io.out_x
-  wb.io.in_x(5)<>mul.io.out_x
-  wb.io.in_v(0)<>valu.io.out
-  wb.io.in_v(1)<>fpu.io.out_v
-  wb.io.in_v(2)<>lsu2wb.io.out_v
-  wb.io.in_v(3)<>sfu.io.out_v
-  wb.io.in_v(4)<>mul.io.out_v
-  wb.io.in_v(5)<>tensorcore.io.out_v
-  wb.io.in_v(6)<>csrfile.io.out_v
+  // LSU2WB remains SM-shared. Its global wid selects exactly one local
+  // writeback LSU slot; all ordinary compute results already stayed local.
+  val lsuScalarOwner = PipeSubcoreHelpers.subcoreValue(lsu2wb.io.out_x.bits.warp_id)
+  val lsuVecOwner = PipeSubcoreHelpers.subcoreValue(lsu2wb.io.out_v.bits.warp_id)
+  for (sc <- 0 until activeSubcoreCount) {
+    val wb = localWritebacks(sc)
+    wb.io.lsu_scalar.valid := lsu2wb.io.out_x.valid && lsuScalarOwner === sc.U
+    wb.io.lsu_scalar.bits := localizeWriteScalar(lsu2wb.io.out_x.bits)
+    wb.io.lsu_vec.valid := lsu2wb.io.out_v.valid && lsuVecOwner === sc.U
+    wb.io.lsu_vec.bits := localizeWriteVec(lsu2wb.io.out_v.bits)
+  }
+  lsu2wb.io.out_x.ready := MuxLookup(lsuScalarOwner, false.B)(
+    (0 until activeSubcoreCount).map(sc => sc.U -> localWritebacks(sc).io.lsu_scalar.ready)
+  )
+  lsu2wb.io.out_v.ready := MuxLookup(lsuVecOwner, false.B)(
+    (0 until activeSubcoreCount).map(sc => sc.U -> localWritebacks(sc).io.lsu_vec.ready)
+  )
 
   val activeCycles = RegInit(0.U(64.W))
   val totalScalarIssued = RegInit(0.U(64.W))
@@ -465,18 +678,44 @@ class pipe() extends Module{
     ctrl.csr.orR || ctrl.barrier || ctrl.simt_stack || ctrl.branch.orR
   }
 
-  val anyBufferedInst = VecInit(ibuffer.io.out.map(_.valid)).asUInt.orR
-  val anySchedulableInst = VecInit((0 until num_warp).map(i => ibuffer.io.out(i).valid && warp_sche.io.warp_ready(i))).asUInt.orR
-  val anyScoreExeBlockedInst = VecInit((0 until num_warp).map(i => ibuffer.io.out(i).valid && (scoreboardBusy(i) || warp_sche.io.exe_busy(i)))).asUInt.orR
-  val anyBarrierBlockedInst = VecInit((0 until num_warp).map(i => ibuffer.io.out(i).valid && warp_sche.io.barrier_busy(i))).asUInt.orR
-  val noIssueFire = !issueX.io.in.fire && !issueV.io.in.fire
-  val noIssueInput = !issueX.io.in.valid && !issueV.io.in.valid
+  val localIssueX = subcoreIbuffer2issue.map(_.io.out_x)
+  val localIssueV = subcoreIbuffer2issue.map(_.io.out_v)
+  val issueXFireCount = PopCount(VecInit(localIssueX.map(_.fire)))
+  val issueVFireCount = PopCount(VecInit(localIssueV.map(_.fire)))
+  val issueXMemFireCount = PopCount(VecInit(localIssueX.map(in => in.fire && in.bits.mem)))
+  val issueVMemFireCount = PopCount(VecInit(localIssueV.map(in => in.fire && in.bits.mem)))
+  val issueXCtrlFireCount = PopCount(VecInit(localIssueX.map(in => in.fire && !in.bits.mem && isCtrlInst(in.bits))))
+  val issueVCtrlFireCount = PopCount(VecInit(localIssueV.map(in => in.fire && !in.bits.mem && isCtrlInst(in.bits))))
+  val anyIssueFire = issueXFireCount.orR || issueVFireCount.orR
+  val anyIssueInput = VecInit((localIssueX ++ localIssueV).map(_.valid)).asUInt.orR
+  val anyIssueXBlocked = VecInit(localIssueX.map(in => in.valid && !in.ready)).asUInt.orR
+  val anyIssueVBlocked = VecInit(localIssueV.map(in => in.valid && !in.ready)).asUInt.orR
+
+  if (INST_CNT_2) {
+    inst_cnt_xv(0) := inst_cnt_xv(0) + issueXFireCount
+    inst_cnt_xv(1) := inst_cnt_xv(1) + issueVFireCount
+  }
+
+  val anyBufferedInst = VecInit(ibuffers.flatMap(_.io.out.map(_.valid))).asUInt.orR
+  val anySchedulableInst = VecInit((0 until num_warp).map { i =>
+    val sc = i & (num_subcore - 1)
+    val local = i >> subcore_sel_bits
+    ibuffers(sc).io.out(local).valid && warpSchedulers(sc).io.warp_ready(local)
+  }).asUInt.orR
+  val anyScoreExeBlockedInst = VecInit((0 until num_warp).map(i =>
+    ibuffers(i & (num_subcore - 1)).io.out(i >> subcore_sel_bits).valid && scoreboardBusy(i)
+  )).asUInt.orR
+  val anyBarrierBlockedInst = VecInit((0 until num_warp).map(i =>
+    ibuffers(i & (num_subcore - 1)).io.out(i >> subcore_sel_bits).valid &&
+      lifecycleCtrlScaffold.io.global_barrier_wait(i)
+  )).asUInt.orR
+  val noIssueFire = !anyIssueFire
+  val noIssueInput = !anyIssueInput
   val dataDepStall = noIssueFire && noIssueInput && anyBufferedInst && !anySchedulableInst && anyScoreExeBlockedInst
   val barrierStall = noIssueFire && noIssueInput && anyBufferedInst && !anySchedulableInst &&
     !anyScoreExeBlockedInst && anyBarrierBlockedInst
   val frontendStall = noIssueFire && noIssueInput && !dataDepStall && !barrierStall
-
-  val flushEvent = warp_sche.io.flush.valid && !RegNext(warp_sche.io.flush.valid, false.B)
+  val flushEvent = anyFrontendFlushGlobal && !RegNext(anyFrontendFlushGlobal, false.B)
 
   when(io.perfReset){
     activeCycles := 0.U
@@ -496,32 +735,17 @@ class pipe() extends Module{
   }.elsewhen(io.perfEnable){
     activeCycles := activeCycles + 1.U
 
-    when(issueX.io.in.fire){
-      totalScalarIssued := totalScalarIssued + 1.U
-      when(issueX.io.in.bits.ctrl.mem){
-        memIssued := memIssued + 1.U
-      }.elsewhen(isCtrlInst(issueX.io.in.bits.ctrl)){
-        ctrlIssued := ctrlIssued + 1.U
-      }.otherwise{
-        computeIssued := computeIssued + 1.U
-      }
-    }
+    totalScalarIssued := totalScalarIssued + issueXFireCount
+    totalVectorIssued := totalVectorIssued + issueVFireCount
+    memIssued := memIssued + issueXMemFireCount + issueVMemFireCount
+    ctrlIssued := ctrlIssued + issueXCtrlFireCount + issueVCtrlFireCount
+    computeIssued := computeIssued + issueXFireCount + issueVFireCount -
+      issueXMemFireCount - issueVMemFireCount - issueXCtrlFireCount - issueVCtrlFireCount
 
-    when(issueV.io.in.fire){
-      totalVectorIssued := totalVectorIssued + 1.U
-      when(issueV.io.in.bits.ctrl.mem){
-        memIssued := memIssued + 1.U
-      }.elsewhen(isCtrlInst(issueV.io.in.bits.ctrl)){
-        ctrlIssued := ctrlIssued + 1.U
-      }.otherwise{
-        computeIssued := computeIssued + 1.U
-      }
-    }
-
-    when(issueX.io.in.valid && !issueX.io.in.ready){
+    when(anyIssueXBlocked){
       execStructuralHazardCyclesX := execStructuralHazardCyclesX + 1.U
     }
-    when(issueV.io.in.valid && !issueV.io.in.ready){
+    when(anyIssueVBlocked){
       execStructuralHazardCyclesV := execStructuralHazardCyclesV + 1.U
     }
     when(dataDepStall){
@@ -536,10 +760,10 @@ class pipe() extends Module{
     when(flushEvent){
       controlHazardFlushCount := controlHazardFlushCount + 1.U
     }
-    when(issueV.io.in.valid && issueV.io.in.bits.ctrl.mem && !issueV.io.in.ready){
+    when(VecInit(localIssueV.map(in => in.valid && in.bits.mem && !in.ready)).asUInt.orR){
       lsuBackpressureCycles := lsuBackpressureCycles + 1.U
     }
-    when(ibuffer.io.in.valid && !ibuffer.io.in.ready){
+    when(VecInit(ibuffers.map(bank => bank.io.in.valid && !bank.io.in.ready)).asUInt.orR){
       ibufferFullCycles := ibufferFullCycles + 1.U
     }
   }
@@ -564,5 +788,5 @@ class pipe() extends Module{
     perf.ctrlIssued := ctrlIssued
   }
 
-  issue_stall:=(~issueX.io.in.ready).asBool | (~issueV.io.in.ready).asBool//scoreb.io.delay | issue.io.in.ready
+  issue_stall := anyIssueXBlocked || anyIssueVBlocked
 }

--- a/ventus/src/pipeline/scoreboard.scala
+++ b/ventus/src/pipeline/scoreboard.scala
@@ -140,4 +140,33 @@ class Scoreboard extends Module{
   dontTouch(readf)
   dontTouch(io)
   io.delay:=read1|read2|read3|readm|readw|readb|readf|read_op_colV|read_op_colX
+
+}
+
+class SubcoreScoreboardBankIO(val nWarps: Int) extends Bundle {
+  val warp = Vec(nWarps, new scoreboardIO)
+}
+
+class SubcoreScoreboardBank(val nWarps: Int) extends Module {
+  val io = IO(new SubcoreScoreboardBankIO(nWarps))
+  private val scoreboards = Seq.fill(nWarps)(Module(new Scoreboard))
+
+  for (wid <- 0 until nWarps) {
+    val external = io.warp(wid)
+    val scoreboard = scoreboards(wid).io
+    scoreboard.ibuffer_if_ctrl := external.ibuffer_if_ctrl
+    scoreboard.if_ctrl := external.if_ctrl
+    scoreboard.wb_v_ctrl := external.wb_v_ctrl
+    scoreboard.wb_x_ctrl := external.wb_x_ctrl
+    scoreboard.if_fire := external.if_fire
+    scoreboard.br_ctrl := external.br_ctrl
+    scoreboard.fence_end := external.fence_end
+    scoreboard.wb_v_fire := external.wb_v_fire
+    scoreboard.wb_x_fire := external.wb_x_fire
+    scoreboard.op_colV_in_fire := external.op_colV_in_fire
+    scoreboard.op_colV_out_fire := external.op_colV_out_fire
+    scoreboard.op_colX_in_fire := external.op_colX_in_fire
+    scoreboard.op_colX_out_fire := external.op_colX_out_fire
+    external.delay := scoreboard.delay
+  }
 }

--- a/ventus/src/pipeline/warp_schedule.scala
+++ b/ventus/src/pipeline/warp_schedule.scala
@@ -11,12 +11,19 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{Instantiate, instantiable, public}
 import chisel3.util._
 import top.parameters._
 import gvm._
 
-class warp_scheduler extends Module{
-  val io = IO(new Bundle{
+@instantiable
+class warp_scheduler(val nWarps: Int = num_warp) extends Module{
+  private val localWarpIdxWidth = if (nWarps == 1) 1 else log2Ceil(nWarps)
+  private def localWarpIdx(wid: UInt): UInt = {
+    if (nWarps == 1) 0.U(1.W) else wid(localWarpIdxWidth - 1, 0)
+  }
+
+  @public val io = IO(new Bundle{
     val pc_reset = Input(Bool())
     val warpReq=Flipped(Decoupled(new warpReqData)) //new warp
     val warpRsp=Decoupled(new warpRspData) //endprg
@@ -27,13 +34,13 @@ class warp_scheduler extends Module{
     val branch = Flipped(DecoupledIO(new BranchCtrl)) //branch, flush pipeline
     val warp_control=Flipped(DecoupledIO(new warpSchedulerExeData)) //engprg and barrier
     val issued_warp=Flipped(Valid(UInt(depth_warp.W))) //not use
-    val scoreboard_busy=Input(UInt(num_warp.W)) //scoreboard race
-    val exe_busy=Input(UInt(num_warp.W)) //exe race
+    val scoreboard_busy=Input(UInt(nWarps.W)) //scoreboard race
+    val exe_busy=Input(UInt(nWarps.W)) //exe race
     //val pc_icache_ready=Input(Vec(num_warp,Bool()))
-    val pc_ibuffer_ready=Input(Vec(num_warp,UInt(depth_ibuffer.W))) //ibuffer ready
+    val pc_ibuffer_ready=Input(Vec(nWarps,UInt(depth_ibuffer.W))) //ibuffer ready
     val asid =  if(MMU_ENABLED) Some(Output(UInt(KNL_ASID_WIDTH.W))) else None // 2ibuffer
-    val warp_ready=Output(UInt(num_warp.W)) //to issue
-    val barrier_busy = Output(UInt(num_warp.W))
+    val warp_ready=Output(UInt(nWarps.W)) //to issue
+    val barrier_busy = Output(UInt(nWarps.W))
     val flush=(ValidIO(UInt(depth_warp.W)))
     val flushCache=(ValidIO(UInt(depth_warp.W)))
     val CTA2csr=ValidIO(new warpReqData) //redirect warpreq
@@ -49,7 +56,8 @@ class warp_scheduler extends Module{
   val warp_end_id=io.warp_control.bits.ctrl.wid
   val current_warp=RegInit(0.U(depth_warp.W))
   val next_warp=WireInit(current_warp)
-  io.branch.ready:= !io.flushCache.valid
+  val flushCacheSameWid = io.flushCache.valid && io.flushCache.bits === io.branch.bits.wid
+  io.branch.ready:= !io.flushCache.valid || !flushCacheSameWid
   io.warp_control.ready:= !io.branch.fire & !io.flushCache.valid
 
   io.warpReq.ready:=true.B
@@ -59,15 +67,15 @@ class warp_scheduler extends Module{
   io.CTA2csr.bits:=io.warpReq.bits
   io.CTA2csr.valid:=io.warpReq.valid
 
-  val new_warpid = io.warpReq.bits.wid
+  val new_warpid = localWarpIdx(io.warpReq.bits.wid)
 
   if(MMU_ENABLED){
-    val asidReg = Reg(Vec(num_warp,UInt(KNL_ASID_WIDTH.W)))
+    val asidReg = Reg(Vec(nWarps,UInt(KNL_ASID_WIDTH.W)))
     when(io.warpReq.fire){
       asidReg(new_warpid) := io.warpReq.bits.CTAdata.dispatch2cu_knl_asid.getOrElse(0.U).asUInt
     }
-    io.asid.get := asidReg(io.pc_rsp.bits.warpid)
-    io.pc_req.bits.asid.get := asidReg(next_warp)
+    io.asid.get := asidReg(localWarpIdx(io.pc_rsp.bits.warpid))
+    io.pc_req.bits.asid.get := asidReg(localWarpIdx(next_warp))
   }
 
 
@@ -76,29 +84,34 @@ class warp_scheduler extends Module{
   io.flushCache.valid:=io.pc_rsp.valid&io.pc_rsp.bits.status(0)
   io.flushCache.bits:=io.pc_rsp.bits.warpid
 
-  val pcControl=VecInit(Seq.fill(num_warp)(Module(new PCcontrol()).io))
+  val pcControl = VecInit(Seq.fill(nWarps)(Instantiate(new PCcontrol()).io))
   //val pcReplay=VecInit(pcControl.map(x=>RegEnable(x.PC_next,(x.PC_src===2.U)&(!x.PC_replay))))
   //val warp_memory_idle=Reg(Vec(num_warp,Bool()))
   //val warp_barrier_array=RegInit(0.U(num_warp.W))
   //val block_warp_waiting=RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp.W)))) // if meet barrier, switch and set 1. all 1 -> all 0.
-  val warp_init_addr=(VecInit(Seq.fill(num_warp)(0.U(32.W))))//,172.U,176.U) //初值怎么传进去，这是个问题？建议走CSR，并且是vec version的
-  pcControl.foreach{
-    x=>{
-      x.New_PC:=io.branch.bits.new_pc
-      x.PC_replay:=true.B
-      x.PC_src:=0.U
-      x.mask_i:=0.U
-    }
+  val warp_init_addr=(VecInit(Seq.fill(nWarps)(0.U(32.W))))//,172.U,176.U) //初值怎么传进去，这是个问题？建议走CSR，并且是vec version的
+  pcControl.foreach { x =>
+    x.New_PC := io.branch.bits.new_pc
+    x.PC_replay := true.B
+    x.PC_src := 0.U
+    x.mask_i := 0.U
   }
-  val pc_ready=Wire(Vec(num_warp,Bool()))
+  val pc_ready = WireInit(VecInit(Seq.fill(nWarps)(false.B)))
 
-
-  current_warp:=next_warp
-  pcControl(next_warp).PC_replay:= (!io.pc_req.ready)|(!pc_ready(next_warp))
-  pcControl(next_warp).PC_src:=2.U
-  io.pc_req.bits.addr := pcControl(next_warp).PC_next
+  val next_warp_local = localWarpIdx(next_warp)
+  io.pc_req.valid := false.B
+  io.pc_req.bits.addr := 0.U
+  io.pc_req.bits.warpid := 0.U
+  io.pc_req.bits.source := 0.U
+  io.pc_req.bits.wf_tag := 0.U
+  io.pc_req.bits.frontend_gen := 0.U
+  io.pc_req.bits.mask := 0.U
+  current_warp := next_warp
+  pcControl(next_warp_local).PC_replay := !io.pc_req.ready || !pc_ready(next_warp_local)
+  pcControl(next_warp_local).PC_src := 2.U
+  io.pc_req.bits.addr := pcControl(next_warp_local).PC_next
   io.pc_req.bits.warpid := next_warp
-  io.pc_req.bits.mask := pcControl(next_warp).mask_o
+  io.pc_req.bits.mask := pcControl(next_warp_local).mask_o
 
 
   io.wg_id_lookup:=Mux(!io.warp_control.bits.ctrl.simt_stack_op,warp_end_id,io.warpRsp.bits.wid) //barrier的时候没有warp_end，只是叫这个名字
@@ -117,12 +130,10 @@ class warp_scheduler extends Module{
   val new_wg_wf_count=io.warpReq.bits.CTAdata.dispatch2cu_wg_wf_count
   val end_wg_id=io.wg_id_tag(TAG_WIDTH-1, WF_ID_WIDTH)
   val end_wf_id=io.wg_id_tag(WF_ID_WIDTH-1, 0)
-  val warp_bar_data=RegInit(0.U(num_warp.W))  // 0 means not locked by barrier
-  val warp_bar_belong=RegInit(VecInit(Seq.fill(num_block)(0.U(num_warp.W))))
-
-
+  val warp_bar_data=RegInit(0.U(nWarps.W))  // 0 means not locked by barrier
+  val warp_bar_belong=RegInit(VecInit(Seq.fill(num_block)(0.U(nWarps.W))))
   when(io.warpReq.fire){
-    warp_bar_belong(new_wg_id):=warp_bar_belong(new_wg_id) | (1.U<<io.warpReq.bits.wid).asUInt  //显示warp中有哪些属于wg
+    warp_bar_belong(new_wg_id):=warp_bar_belong(new_wg_id) | (1.U<<new_warpid).asUInt  //显示warp中有哪些属于wg
 //    warp_bar_exp(new_wg_id):= warp_bar_exp(new_wg_id) | (1.U<<io.warpReq.bits.wid).asUInt
     when(!warp_bar_lock(new_wg_id)) {
       warp_bar_cur(new_wg_id) := 0.U
@@ -131,12 +142,12 @@ class warp_scheduler extends Module{
   }
   when(io.warpRsp.fire){
 //    warp_bar_exp(end_wg_id):=warp_bar_exp(end_wg_id) & (~(1.U<<io.warpRsp.bits.wid)).asUInt
-    warp_bar_belong(end_wg_id):=warp_bar_belong(end_wg_id) & (~(1.U<<io.warpRsp.bits.wid)).asUInt
+    warp_bar_belong(end_wg_id):=warp_bar_belong(end_wg_id) & (~(1.U<<localWarpIdx(io.warpRsp.bits.wid))).asUInt
   }
   warp_bar_lock:=warp_bar_belong.map(x=>x.orR)
   when(io.warp_control.fire&(!io.warp_control.bits.ctrl.simt_stack_op)){ //means barrrier
     warp_bar_cur(end_wg_id):=warp_bar_cur(end_wg_id) | (1.U<<end_wf_id).asUInt
-    warp_bar_data:=warp_bar_data | (1.U<<io.warp_control.bits.ctrl.wid).asUInt
+    warp_bar_data:=warp_bar_data | (1.U<<localWarpIdx(io.warp_control.bits.ctrl.wid)).asUInt
     when((warp_bar_cur(end_wg_id) | (1.U<<end_wf_id).asUInt) === warp_bar_exp(end_wg_id)){
       warp_bar_cur(end_wg_id):=0.U
       warp_bar_data:=warp_bar_data & (~warp_bar_belong(end_wg_id)).asUInt
@@ -175,51 +186,48 @@ class warp_scheduler extends Module{
   io.flushDCache.bits := need_flush
 
 
-  val warp_active=RegInit(0.U(num_warp.W))
+  val warp_active=RegInit(0.U(nWarps.W))
 
-
-
-  warp_active:=(warp_active | ((1.U<<io.warpReq.bits.wid).asUInt&Fill(num_warp,io.warpReq.fire))) & (~( Fill(num_warp,warp_end)&(1.U<<warp_end_id).asUInt )).asUInt
+  val warp_end_local = localWarpIdx(warp_end_id)
+  warp_active:=(warp_active | ((1.U<<new_warpid).asUInt&Fill(nWarps,io.warpReq.fire))) & (~( Fill(nWarps,warp_end)&(1.U<<warp_end_local).asUInt )).asUInt
   val warp_ready=(~(warp_bar_data | io.scoreboard_busy | io.exe_busy | (~warp_active).asUInt)).asUInt
   io.warp_ready:=warp_ready
   io.barrier_busy := warp_bar_data
-  for (i<- num_warp-1 to 0 by -1){
-    pc_ready(i):= io.pc_ibuffer_ready(i) & warp_active(i) 
-    when(pc_ready(i)){next_warp:=i.asUInt}
+  for (i <- nWarps - 1 to 0 by -1) {
+    pc_ready(i) := io.pc_ibuffer_ready(i).orR && warp_active(i)
+    when(pc_ready(i)) { next_warp := i.asUInt }
   }
-  io.pc_req.valid:=pc_ready(next_warp)
-  //lock one warp to execute
-  //next_warp:=0.U
-  if(SINGLE_INST) next_warp:=0.U
+  io.pc_req.valid := pc_ready(next_warp)
+  if (SINGLE_INST) next_warp := 0.U
 
-
-
-  when(io.pc_rsp.valid&io.pc_rsp.bits.status(0)){//miss acknowledgement
-    pcControl(io.pc_rsp.bits.warpid).PC_replay:=false.B
-    pcControl(io.pc_rsp.bits.warpid).PC_src:=3.U
-    pcControl(io.pc_rsp.bits.warpid).New_PC:=io.pc_rsp.bits.addr//pcReplay(io.pc_rsp.bits.warpid)
-    pcControl(io.pc_rsp.bits.warpid).mask_i:=io.pc_rsp.bits.mask
+  when(io.pc_rsp.valid && io.pc_rsp.bits.status(0)) {
+    val rsp_warp_local = localWarpIdx(io.pc_rsp.bits.warpid)
+    pcControl(rsp_warp_local).PC_replay := false.B
+    pcControl(rsp_warp_local).PC_src := 3.U
+    pcControl(rsp_warp_local).New_PC := io.pc_rsp.bits.addr
+    pcControl(rsp_warp_local).mask_i := io.pc_rsp.bits.mask
   }
 
-  when(io.branch.fire&io.branch.bits.jump){
-    pcControl(io.branch.bits.wid).PC_replay:=false.B
-    pcControl(io.branch.bits.wid).PC_src:=1.U
-    pcControl(io.branch.bits.wid).New_PC:=io.branch.bits.new_pc
-    //PC:=io.branch.bits.new_pc
-    when(io.branch.bits.wid===next_warp){
-    io.pc_req.valid:=false.B}
+  when(io.branch.fire && io.branch.bits.jump) {
+    val branch_warp_local = localWarpIdx(io.branch.bits.wid)
+    pcControl(branch_warp_local).PC_replay := false.B
+    pcControl(branch_warp_local).PC_src := 1.U
+    pcControl(branch_warp_local).New_PC := io.branch.bits.new_pc
+    when(io.branch.bits.wid === next_warp) { io.pc_req.valid := false.B }
   }
 
-
-  when(io.warpReq.fire){
-    pcControl(io.warpReq.bits.wid).PC_replay:=false.B
-    pcControl(io.warpReq.bits.wid).PC_src:=1.U
-    pcControl(io.warpReq.bits.wid).New_PC:=io.warpReq.bits.CTAdata.dispatch2cu_start_pc_dispatch
+  when(io.warpReq.fire) {
+    pcControl(new_warpid).PC_replay := false.B
+    pcControl(new_warpid).PC_src := 1.U
+    pcControl(new_warpid).New_PC := io.warpReq.bits.CTAdata.dispatch2cu_start_pc_dispatch
   }
 
-
-  when(io.pc_reset){
-    pcControl.zipWithIndex.foreach{case(x,b)=>{x.PC_src:=1.U;x.New_PC:=warp_init_addr(b);x.PC_replay:=false.B} }
-    io.pc_req.valid:=false.B
+  when(io.pc_reset) {
+    pcControl.zipWithIndex.foreach { case (x, b) =>
+      x.PC_src := 1.U
+      x.New_PC := warp_init_addr(b)
+      x.PC_replay := false.B
+    }
+    io.pc_req.valid := false.B
   }
 }

--- a/ventus/src/pipeline/writeback.scala
+++ b/ventus/src/pipeline/writeback.scala
@@ -11,12 +11,14 @@
 package pipeline
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.util._
 import top.parameters.{SPIKE_OUTPUT, wid_to_check, xLen, GVM_ENABLED}
 import gvm._
 
+@instantiable
 class Branch_back extends Module{
-  val io = IO(new Bundle{
+  @public val io = IO(new Bundle{
     val out=DecoupledIO(new BranchCtrl)
     val in0=Flipped(DecoupledIO(new BranchCtrl))
     val in1=Flipped(DecoupledIO(new BranchCtrl))
@@ -41,7 +43,8 @@ class InstWriteBack extends Bundle{
   val dispatch_id = if(GVM_ENABLED) Some(UInt(32.W)) else None // gvm debug val: unique instruction dispatch id
   val is_extended = if(GVM_ENABLED) Some(Bool()) else None // gvm debug val: whether the instruction is extended
 }
-class Writeback(num_x:Int,num_v:Int) extends Module{
+class Writeback(num_x:Int, num_v:Int, subcoreId: Int) extends Module{
+  require(subcoreId >= 0 && subcoreId < top.parameters.num_subcore)
   val io = IO(new Bundle{
     val out_v=(DecoupledIO(new WriteVecCtrl))
     val out_x=(DecoupledIO(new WriteScalarCtrl))
@@ -63,15 +66,18 @@ class Writeback(num_x:Int,num_v:Int) extends Module{
   arbiter_v.io.in<>fifo_v
   arbiter_x.io.out<>io.out_x
   arbiter_v.io.out<>io.out_v
+  private def observedWarpId(localWid: UInt): UInt = {
+    PipeSubcoreHelpers.internalWid(subcoreId, localWid)
+  }
   //send to operand collector
   if(SPIKE_OUTPUT){
     when(io.out_x.fire/*&&io.out_x.bits.warp_id===wid_to_check.U*/){
-      printf(p"sm ${io.out_x.bits.spike_info.get.sm_id} warp ${Decimal(io.out_x.bits.warp_id)} " +
+      printf(p"sm ${io.out_x.bits.spike_info.get.sm_id} warp ${Decimal(observedWarpId(io.out_x.bits.warp_id))} " +
              p"0x${Hexadecimal(io.out_x.bits.spike_info.get.pc)} 0x${Hexadecimal(io.out_x.bits.spike_info.get.inst)}" +
              p" x${io.out_x.bits.reg_idxw}  ${Hexadecimal(io.out_x.bits.wb_wxd_rd)}\n")
     }
     when(io.out_v.fire/* && io.out_v.bits.warp_id === wid_to_check.U*/) {
-      printf(p"sm ${io.out_v.bits.spike_info.get.sm_id} warp ${Decimal(io.out_v.bits.warp_id)} " +
+      printf(p"sm ${io.out_v.bits.spike_info.get.sm_id} warp ${Decimal(observedWarpId(io.out_v.bits.warp_id))} " +
              p"0x${Hexadecimal(io.out_v.bits.spike_info.get.pc)} 0x${Hexadecimal(io.out_v.bits.spike_info.get.inst)}" +
              p" v${io.out_v.bits.reg_idxw} " +
              p"${Binary(io.out_v.bits.wvd_mask.asUInt)} " +
@@ -88,7 +94,7 @@ class Writeback(num_x:Int,num_v:Int) extends Module{
     gvm_x_wb.io.rd := RegNext(io.out_x.bits.wb_wxd_rd, 0.U(xLen.W)) // int
     gvm_x_wb.io.is_scalar_wb := RegNext(io.out_x.bits.wxd, false.B) // bit
     gvm_x_wb.io.reg_idx := RegNext(io.out_x.bits.reg_idxw.pad(32), 0.U(32.W))
-    gvm_x_wb.io.hardware_warp_id := RegNext(io.out_x.bits.warp_id.pad(32), 0.U(32.W))
+    gvm_x_wb.io.hardware_warp_id := RegNext(observedWarpId(io.out_x.bits.warp_id).pad(32), 0.U(32.W))
     gvm_x_wb.io.pc := RegNext(io.out_x.bits.spike_info.get.pc, 0.U(xLen.W)) // int
     gvm_x_wb.io.inst := RegNext(io.out_x.bits.spike_info.get.inst, 0.U(32.W)) // int
     gvm_x_wb.io.dispatch_id := RegNext(io.out_x.bits.spike_info.get.dispatch_id.get, 0.U(32.W)) // int
@@ -101,7 +107,7 @@ class Writeback(num_x:Int,num_v:Int) extends Module{
     gvm_v_wb.io.rd := io.out_v.bits.wb_wvd_rd.asUInt // UInt - 向量数据转换为一维信号
     gvm_v_wb.io.is_vector_wb := io.out_v.bits.wvd // bit - 向量写回使能
     gvm_v_wb.io.reg_idx := io.out_v.bits.reg_idxw.pad(32)
-    gvm_v_wb.io.hardware_warp_id := io.out_v.bits.warp_id.pad(32)
+    gvm_v_wb.io.hardware_warp_id := observedWarpId(io.out_v.bits.warp_id).pad(32)
     gvm_v_wb.io.pc := io.out_v.bits.spike_info.get.pc // int
     gvm_v_wb.io.inst := io.out_v.bits.spike_info.get.inst // int
     gvm_v_wb.io.dispatch_id := io.out_v.bits.spike_info.get.dispatch_id.get // int

--- a/ventus/src/top/GPGPU_top.scala
+++ b/ventus/src/top/GPGPU_top.scala
@@ -698,6 +698,9 @@ class SM_wrapper(FakeCache: Boolean = false, SV: Option[mmu.SVParam] = None) ext
   icache.io.coreReq.valid:=pipe.io.icache_req.valid
   icache.io.coreReq.bits.addr:=pipe.io.icache_req.bits.addr
   icache.io.coreReq.bits.warpid:=pipe.io.icache_req.bits.warpid
+  icache.io.coreReq.bits.source:=pipe.io.icache_req.bits.source
+  icache.io.coreReq.bits.wf_tag:=pipe.io.icache_req.bits.wf_tag
+  icache.io.coreReq.bits.frontend_gen:=pipe.io.icache_req.bits.frontend_gen
   icache.io.coreReq.bits.mask:=pipe.io.icache_req.bits.mask
   if(MMU_ENABLED){
     icache.io.coreReq.bits.asid.get := pipe.io.icache_req.bits.asid.get
@@ -708,6 +711,9 @@ class SM_wrapper(FakeCache: Boolean = false, SV: Option[mmu.SVParam] = None) ext
   // **** icache coreRsp ****
   pipe.io.icache_rsp.valid:=icache.io.coreRsp.valid
   pipe.io.icache_rsp.bits.warpid:=icache.io.coreRsp.bits.warpid
+  pipe.io.icache_rsp.bits.source:=icache.io.coreRsp.bits.source
+  pipe.io.icache_rsp.bits.wf_tag:=icache.io.coreRsp.bits.wf_tag
+  pipe.io.icache_rsp.bits.frontend_gen:=icache.io.coreRsp.bits.frontend_gen
   pipe.io.icache_rsp.bits.data:=icache.io.coreRsp.bits.data
   pipe.io.icache_rsp.bits.addr:=icache.io.coreRsp.bits.addr
   pipe.io.icache_rsp.bits.status:=icache.io.coreRsp.bits.status

--- a/ventus/src/top/GPGPU_top_nocache.scala
+++ b/ventus/src/top/GPGPU_top_nocache.scala
@@ -75,12 +75,18 @@ class SM_wrapper_nocache() extends Module {
   icache.io.coreReq.valid:=pipe.io.icache_req.valid
   icache.io.coreReq.bits.addr:=pipe.io.icache_req.bits.addr
   icache.io.coreReq.bits.warpid:=pipe.io.icache_req.bits.warpid
+  icache.io.coreReq.bits.source:=pipe.io.icache_req.bits.source
+  icache.io.coreReq.bits.wf_tag:=pipe.io.icache_req.bits.wf_tag
+  icache.io.coreReq.bits.frontend_gen:=pipe.io.icache_req.bits.frontend_gen
   icache.io.coreReq.bits.mask:=pipe.io.icache_req.bits.mask
   if(MMU_ENABLED){ icache.io.coreReq.bits.asid.get := pipe.io.icache_req.bits.asid.get }
   icache.io.coreReq.bits.spike_info.foreach( _ := DontCare )
   // **** icache coreRsp ****
   pipe.io.icache_rsp.valid:=icache.io.coreRsp.valid
   pipe.io.icache_rsp.bits.warpid:=icache.io.coreRsp.bits.warpid
+  pipe.io.icache_rsp.bits.source:=icache.io.coreRsp.bits.source
+  pipe.io.icache_rsp.bits.wf_tag:=icache.io.coreRsp.bits.wf_tag
+  pipe.io.icache_rsp.bits.frontend_gen:=icache.io.coreRsp.bits.frontend_gen
   pipe.io.icache_rsp.bits.data:=icache.io.coreRsp.bits.data
   pipe.io.icache_rsp.bits.addr:=icache.io.coreRsp.bits.addr
   pipe.io.icache_rsp.bits.status:=icache.io.coreRsp.bits.status

--- a/ventus/src/top/parameters.scala
+++ b/ventus/src/top/parameters.scala
@@ -8,6 +8,11 @@ import mmu.SV32.{asidLen, paLen, vaLen}
 object parameters { //notice log2Ceil(4) returns 2.that is ,n is the total num, not the last idx.
   def num_sm = 2
   var num_warp = 8
+  val num_subcore = 4
+  require((num_warp % num_subcore) == 0, s"num_warp ($num_warp) must be divisible by num_subcore ($num_subcore)")
+  def num_warp_per_subcore = num_warp / num_subcore
+  def subcore_sel_bits = log2Ceil(num_subcore)
+  def frontend_gen_width = 16
   var num_thread = 32
   val SINGLE_INST: Boolean = false
   val SPIKE_OUTPUT: Boolean = true
@@ -74,6 +79,8 @@ object parameters { //notice log2Ceil(4) returns 2.that is ,n is the total num, 
   def lsu_num_entry_each_warp = 4 //blocking for each warp
 
   def lsu_nMshrEntry = num_warp // less than num_warp
+  def lsu_local_instr_id_bits = log2Up(lsu_nMshrEntry)
+  def lsu_mem_instr_id_bits = subcore_sel_bits + lsu_local_instr_id_bits
 
   def dcache_NSets: Int = 32
 


### PR DESCRIPTION
## Summary

This PR introduces an SM subcore partition baseline.

It localizes the scheduler, scoreboard, instruction buffer, backend slice, and writeback path per subcore, while keeping frontend, decode, LSU fabric, LSU2WB, DCache, ShareMem, and lifecycle/barrier control shared at SM level.

The branch is based on the latest official `develop` (`78bafb50`) and is squashed into one clean commit.

## Verification

- `rtlsim-no-cache`: 21/21 passed

## Notes

This PR is intended as a reviewable baseline for the subcore migration. It does not split DCache, ShareMem, decode, or CTA/resource management.